### PR TITLE
DeepSelect instead of Select to read MetaData with "." in key

### DIFF
--- a/jdplus-main-base/jdplus-sa-base-parent/jdplus-sa-base-information/src/main/java/jdplus/sa/base/information/SaItemMapping.java
+++ b/jdplus-main-base/jdplus-sa-base-parent/jdplus-sa-base-information/src/main/java/jdplus/sa/base/information/SaItemMapping.java
@@ -91,7 +91,7 @@ public class SaItemMapping {
         }
         InformationSet md = info.getSubSet(METADATA);
         if (md != null) {
-            List<Information<String>> sel = md.select(String.class);
+            List<Information<String>> sel = md.deepSelect(String.class);
             sel.forEach(v -> builder.meta(v.getName(), v.getValue()));
         }
         String name = info.get(NAME, String.class);


### PR DESCRIPTION
We are using meta data for production in JD2 and use '.' as separator for different "level" for grouping purposes or other processes down the line, e.g. saving to database.