### PR TITLE
mmsreFilter method for IFiniteFilter

### DIFF
--- a/jdplus-main-base/jdplus-toolkit-base-parent/jdplus-toolkit-base-core/src/main/java/jdplus/toolkit/base/core/math/linearfilters/AsymmetricFiltersFactory.java
+++ b/jdplus-main-base/jdplus-toolkit-base-parent/jdplus-toolkit-base-core/src/main/java/jdplus/toolkit/base/core/math/linearfilters/AsymmetricFiltersFactory.java
@@ -280,6 +280,13 @@ public class AsymmetricFiltersFactory {
     public IFiniteFilter mmsreFilter(SymmetricFilter sw, int q, FastMatrix U, FastMatrix Z, double[] dz, IntToDoubleFunction k, double passBand, double tweight) {
         double[] w = sw.weightsToArray();
         int h = w.length / 2;
+        IFiniteFilter rf = FiniteFilter.ofInternal(w, -h);
+        return mmsreFilter(rf, q, U, Z, dz, k, passBand, tweight);   
+    }
+    
+    public IFiniteFilter mmsreFilter(IFiniteFilter rf, int q, FastMatrix U, FastMatrix Z, double[] dz, IntToDoubleFunction k, double passBand, double tweight) {
+        double[] w = rf.weightsToArray();
+        int h = Math.abs(rf.getLowerBound());
         int nv = h + q + 1;
         int ncolu = U.getColumnsCount();
         DataBlock wp = DataBlock.of(w, 0, nv);


### PR DESCRIPTION
New method for `mmsreFilter` to be able to use general filter as reference instead of only symmetric filters (for `rjd3filters`)