### PR TITLE
Change 'axis' to 'axes' in configure option to show/hide axes on charts

### DIFF
--- a/jdplus-main-desktop/jdplus-toolkit-desktop-plugin/src/main/java/internal/ui/components/JTsChartConfig.java
+++ b/jdplus-main-desktop/jdplus-toolkit-desktop-plugin/src/main/java/internal/ui/components/JTsChartConfig.java
@@ -101,7 +101,7 @@ public final class JTsChartConfig {
             b.reset("Chart display");
             b.withBoolean().selectField(bean, "legendVisible").display("Show legend").description("Whether the legend should be shown or not").add();
             b.withBoolean().selectField(bean, "titleVisible").display("Show title").description("Whether the title should be shown or not").add();
-            b.withBoolean().selectField(bean, "axisVisible").display("Show axis").description("Whether the axis should be shown or not").add();
+            b.withBoolean().selectField(bean, "axisVisible").display("Show axes").description("Whether both axes should be shown or not").add();
             b.with(String.class).selectField(bean, "title").display("Title").description("Title of the chart").add();
             sheet.put(b.build());
             b.reset("Series display");


### PR DESCRIPTION
The option to `Show axis` when configuring a chart will simultaneously show or hide both axes, hence the pluralised form of the word should be used to be clearer to the user.

![image](https://github.com/user-attachments/assets/3d8f5176-f201-4dc8-854b-e6ad1b20b1f6)