### PR TITLE
Integration of frequency in the specifications

### DIFF
--- a/jdplus-main-base/jdplus-sa-base-parent/jdplus-sa-base-api/src/main/java/jdplus/sa/base/api/SaDefinition.java
+++ b/jdplus-main-base/jdplus-sa-base-parent/jdplus-sa-base-api/src/main/java/jdplus/sa/base/api/SaDefinition.java
@@ -17,15 +17,15 @@
 package jdplus.sa.base.api;
 
 import jdplus.toolkit.base.api.timeseries.Ts;
+import jdplus.toolkit.base.api.timeseries.TsInformationType;
 
 /**
- * 
+ *
  * @author PALATEJ
  */
 @lombok.Value
-@lombok.Builder(builderClassName="Builder", toBuilder = true)
+@lombok.Builder(builderClassName = "Builder", toBuilder = true)
 public class SaDefinition {
-    
 
     /**
      * Initial specification. Reference for any relaxing of some elements of the
@@ -35,8 +35,10 @@ public class SaDefinition {
     SaSpecification domainSpec;
 
     /**
-     * Specification used for the current estimation. The domainSpec is used if the estimationSpec is missing (see activeSpecification)
+     * Specification used for the current estimation. The domainSpec is used if
+     * the estimationSpec is missing (see activeSpecification)
      */
+    @lombok.NonNull
     SaSpecification estimationSpec;
 
     /**
@@ -45,18 +47,27 @@ public class SaDefinition {
     @lombok.EqualsAndHashCode.Exclude
     EstimationPolicyType policy;
 
-   
     /**
      * Time series
      */
     @lombok.NonNull
     Ts ts;
 
-    public SaSpecification activeSpecification() {
-        return estimationSpec == null ? domainSpec : estimationSpec;
+    public static class Builder {
+
+        public SaDefinition build() {
+            if (estimationSpec == null) {
+                if (ts.getType().encompass(TsInformationType.Data)) {
+                    estimationSpec = domainSpec.setFrequency(ts.getData().getAnnualFrequency());
+                } else {
+                    estimationSpec = domainSpec;
+                }
+            }
+            return new SaDefinition(domainSpec, estimationSpec, policy, ts);
+        }
     }
-    
-    public static Builder builder(){
+
+    public static Builder builder() {
         return new Builder()
                 .policy(EstimationPolicyType.None);
     }

--- a/jdplus-main-base/jdplus-sa-base-parent/jdplus-sa-base-api/src/main/java/jdplus/sa/base/api/SaDefinition.java
+++ b/jdplus-main-base/jdplus-sa-base-parent/jdplus-sa-base-api/src/main/java/jdplus/sa/base/api/SaDefinition.java
@@ -56,12 +56,15 @@ public class SaDefinition {
     public static class Builder {
 
         public SaDefinition build() {
+            boolean hasData = ts.getType().encompass(TsInformationType.Data);
+            if (hasData && domainSpec.getFrequency() <= 0) {
+                domainSpec = domainSpec.setFrequency(ts.getData().getAnnualFrequency());
+            }
             if (estimationSpec == null) {
-                if (ts.getType().encompass(TsInformationType.Data)) {
-                    estimationSpec = domainSpec.setFrequency(ts.getData().getAnnualFrequency());
-                } else {
-                    estimationSpec = domainSpec;
-                }
+                estimationSpec = domainSpec;
+            } else {
+                // necessary for legacy spec
+                estimationSpec = estimationSpec.setFrequency(ts.getData().getAnnualFrequency());
             }
             return new SaDefinition(domainSpec, estimationSpec, policy, ts);
         }

--- a/jdplus-main-base/jdplus-sa-base-parent/jdplus-sa-base-api/src/main/java/jdplus/sa/base/api/SaItem.java
+++ b/jdplus-main-base/jdplus-sa-base-parent/jdplus-sa-base-api/src/main/java/jdplus/sa/base/api/SaItem.java
@@ -115,7 +115,7 @@ public final class SaItem {
         SaDefinition ndef = SaDefinition.builder()
                 .ts(definition.getTs())
                 .domainSpec(dspec)
-                .estimationSpec(definition.activeSpecification())
+                .estimationSpec(definition.getEstimationSpec())
                 .policy(EstimationPolicyType.None)
                 .build();
         return new SaItem(name, ndef, meta, priority, estimation, processed);
@@ -214,7 +214,7 @@ public final class SaItem {
                     // Unoptimized solution
                     // SaSpecification pointSpec = estimation.getPointSpec();
                     //if (pointSpec == null)
-                    SaSpecification pointSpec = definition.activeSpecification();
+                    SaSpecification pointSpec = definition.getEstimationSpec();
                     SaDefinition pdef = SaDefinition.builder()
                             .ts(definition.getTs())
                             .domainSpec(pointSpec)
@@ -261,10 +261,10 @@ public final class SaItem {
     public SaDocument asDocument() {
         SaEstimation e = getEstimation();
         if (e == null) {
-            return new SaDocument(name, definition.getTs(), definition.activeSpecification(),
+            return new SaDocument(name, definition.getTs(), definition.getEstimationSpec(),
                     null, null, ProcQuality.Undefined);
         } else {
-            return new SaDocument(name, definition.getTs(), definition.activeSpecification(),
+            return new SaDocument(name, definition.getTs(), definition.getEstimationSpec(),
                     e.getResults(), e.getDiagnostics(), e.getQuality());
         }
     }
@@ -283,14 +283,14 @@ public final class SaItem {
             SaDefinition ndef = SaDefinition.builder()
                     .ts(nts)
                     .domainSpec(dspec)
-                    .estimationSpec(definition.activeSpecification())
+                    .estimationSpec(definition.getEstimationSpec())
                     .policy(policy.getPolicy())
                     .build();
             return new SaItem(name, ndef, meta, priority, null, false);
         } else {
             SaSpecification pspec = estimation.getPointSpec();
             SaProcessingFactory fac = SaManager.factoryFor(dspec);
-            SaSpecification espec = definition.activeSpecification();
+            SaSpecification espec = definition.getEstimationSpec();
             if (fac != null) {
                 if (pspec != null) {
                     TsDomain frozenSpan = policy.getFrozenSpan();

--- a/jdplus-main-base/jdplus-sa-base-parent/jdplus-sa-base-api/src/main/java/jdplus/sa/base/api/SaManager.java
+++ b/jdplus-main-base/jdplus-sa-base-parent/jdplus-sa-base-api/src/main/java/jdplus/sa/base/api/SaManager.java
@@ -58,7 +58,7 @@ public class SaManager {
         for (SaProcessingFactory fac : all) {
             SaSpecification dspec = fac.decode(spec);
             if (dspec != null) {
-                return fac.processor(dspec).process(series, context, log);
+                return fac.processor(dspec.setFrequency(series.getAnnualFrequency())).process(series, context, log);
             }
         }
         return null;
@@ -66,13 +66,14 @@ public class SaManager {
 
     public SaEstimation process(SaDefinition def, ModellingContext context, boolean verbose) {
         List<SaProcessingFactory> all = processors();
-        SaSpecification spec = def.activeSpecification();
+        SaSpecification spec = def.getEstimationSpec();
         for (SaProcessingFactory fac : all) {
             SaSpecification dspec = fac.decode(spec);
             if (dspec != null) {
                 ProcessingLog log = verbose ? new DefaultProcessingLog() : ProcessingLog.dummy();
-                SaProcessor processor = fac.processor(dspec);
-                GenericExplorable rslt = processor.process(def.getTs().getData(), context, log);
+                TsData data = def.getTs().getData();
+                SaProcessor processor = fac.processor(spec);
+                GenericExplorable rslt = processor.process(data, context, log);
                 if (rslt.isValid()) {
                     List<String> warnings = new ArrayList<>();
                     List<ProcDiagnostic> tests = new ArrayList<>();

--- a/jdplus-main-base/jdplus-sa-base-parent/jdplus-sa-base-api/src/main/java/jdplus/sa/base/api/SaSpecification.java
+++ b/jdplus-main-base/jdplus-sa-base-parent/jdplus-sa-base-api/src/main/java/jdplus/sa/base/api/SaSpecification.java
@@ -25,4 +25,6 @@ import jdplus.toolkit.base.api.processing.ProcSpecification;
 public interface SaSpecification extends ProcSpecification{
     public static final String FAMILY = "Seasonal adjustment";
     
+    int getFrequency();
+    SaSpecification setFrequency(int nfreq);
 }

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-api/src/main/java/jdplus/tramoseats/base/api/tramo/TramoFrequency.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-api/src/main/java/jdplus/tramoseats/base/api/tramo/TramoFrequency.java
@@ -14,7 +14,7 @@
  * See the Licence for the specific language governing permissions and
  * limitations under the Licence.
  */
-package jdplus.x13.base.api.regarima;
+package jdplus.tramoseats.base.api.tramo;
 
 import lombok.NonNull;
 import nbbrd.design.Development;
@@ -29,7 +29,7 @@ import nbbrd.design.StaticFactoryMethod;
  */
 @RepresentableAsInt
 @Development(status = Development.Status.Release)
-public enum X13Frequency {
+public enum TramoFrequency {
     /**
      * Undefined frequency. For legacy purposes
      */
@@ -47,15 +47,23 @@ public enum X13Frequency {
      */
     HalfYearly(2),
     /**
+     * One event every four months
+     */
+    QuadriMonthly(3),
+    /*
      * One event every quarter
      */
     Quarterly(4),
+    /*
+     * One event every two months
+     */
+    BiMonthly(6),
     /**
      * One event every month
      */
     Monthly(12);
 
-    private static final X13Frequency[] ENUMS = X13Frequency.values();
+    private static final TramoFrequency[] ENUMS = TramoFrequency.values();
 
     /**
      * Enum correspondence to an integer
@@ -65,7 +73,7 @@ public enum X13Frequency {
      */
     @StaticFactoryMethod
     public static @NonNull
-    X13Frequency parse(int value) throws IllegalArgumentException {
+    TramoFrequency parse(int value) throws IllegalArgumentException {
 
         switch (value) {
             case -1 -> {
@@ -80,8 +88,14 @@ public enum X13Frequency {
             case 2 -> {
                 return HalfYearly;
             }
+            case 3 -> {
+                return QuadriMonthly;
+            }
             case 4 -> {
                 return Quarterly;
+            }
+            case 6 -> {
+                return BiMonthly;
             }
             case 12 -> {
                 return Monthly;
@@ -94,7 +108,7 @@ public enum X13Frequency {
 
     private final int value;
 
-    X13Frequency(final int value) {
+    TramoFrequency(final int value) {
         this.value = value;
     }
 

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-api/src/main/java/jdplus/tramoseats/base/api/tramo/TramoSpec.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-api/src/main/java/jdplus/tramoseats/base/api/tramo/TramoSpec.java
@@ -34,7 +34,7 @@ import lombok.NonNull;
  */
 @Development(status = Development.Status.Beta)
 @lombok.Value
-@lombok.Builder(toBuilder = true,  buildMethodName = "buildWithoutValidation")
+@lombok.Builder(toBuilder = true, buildMethodName = "buildWithoutValidation")
 public final class TramoSpec implements Validatable<TramoSpec>, ProcSpecification {
 
     public static final String METHOD = "tramo";
@@ -47,6 +47,7 @@ public final class TramoSpec implements Validatable<TramoSpec>, ProcSpecificatio
 
     public static final TramoSpec DEFAULT = TramoSpec.builder().build();
 
+    private int frequency;
     /**
      * Gets the predefined Arima specification. The AutoModel and the Arima
      * properties are mutually exclusive specifications: Related TRAMO options:
@@ -59,10 +60,8 @@ public final class TramoSpec implements Validatable<TramoSpec>, ProcSpecificatio
 
     /**
      * Gets the specifications related to the transformation of the original
-     * series. Related TRAMO options: LAM, FCT, UNITS.
-     * -- SETTER --
-     * Sets the specifications related to the transformation of the original
-     * series.
+     * series. Related TRAMO options: LAM, FCT, UNITS. -- SETTER -- Sets the
+     * specifications related to the transformation of the original series.
      *
      * @return The transform specifications
      * @param transform The new transform specifications. Should not be null
@@ -83,9 +82,7 @@ public final class TramoSpec implements Validatable<TramoSpec>, ProcSpecificatio
 
     /**
      * Gets options related to the estimation routine Related TRAMO options:
-     * TOL, TYPE.
-     * -- SETTER --
-     * Sets new options for the estimation routine.
+     * TOL, TYPE. -- SETTER -- Sets new options for the estimation routine.
      *
      * @param estimate The new options
      * @return
@@ -95,9 +92,8 @@ public final class TramoSpec implements Validatable<TramoSpec>, ProcSpecificatio
 
     /**
      * Gets the options for the automatic outliers detection Related TRAMO
-     * options: IATIP, AIO, TC, VA
-     * -- SETTER --
-     * Sets the options for the automatic outliers detection.
+     * options: IATIP, AIO, TC, VA -- SETTER -- Sets the options for the
+     * automatic outliers detection.
      *
      * @return the options for automatic outliers detection.
      * @param outliers The new specifications.
@@ -107,9 +103,7 @@ public final class TramoSpec implements Validatable<TramoSpec>, ProcSpecificatio
 
     /**
      * Gets the specifications for the regression model (including calendar
-     * effects).
-     * -- SETTER --
-     * Sets the specifications for the regression model.
+     * effects). -- SETTER -- Sets the specifications for the regression model.
      *
      * @param regression The new regression specifications.
      * @return The specifications for the regression model.
@@ -119,14 +113,15 @@ public final class TramoSpec implements Validatable<TramoSpec>, ProcSpecificatio
 
     /**
      * Creates a new default specification builder. No transformation, no
-     * regression
-     * variables, no outliers detection, default airline model (without mean).
+     * regression variables, no outliers detection, default airline model
+     * (without mean).
      *
      * @return the builder initialized with default parameters
      */
     @LombokWorkaround
     public static Builder builder() {
         return new Builder()
+                .frequency(0)
                 .transform(TransformSpec.DEFAULT_UNUSED)
                 .estimate(EstimateSpec.DEFAULT)
                 .autoModel(AutoModelSpec.DEFAULT_DISABLED)
@@ -146,9 +141,10 @@ public final class TramoSpec implements Validatable<TramoSpec>, ProcSpecificatio
     }
 
     @Override
-    public AlgorithmDescriptor getAlgorithmDescriptor(){
+    public AlgorithmDescriptor getAlgorithmDescriptor() {
         return DESCRIPTOR_V3;
     }
+
     /**
      * Checks that the AMI is enabled
      *
@@ -168,7 +164,7 @@ public final class TramoSpec implements Validatable<TramoSpec>, ProcSpecificatio
          * Enables/disables the AMI.
          *
          * @param enableAutoModel
-         * @return 
+         * @return
          */
         public Builder usingAutoModel(boolean enableAutoModel) {
             if (autoModel.isEnabled() != enableAutoModel) {
@@ -193,6 +189,27 @@ public final class TramoSpec implements Validatable<TramoSpec>, ProcSpecificatio
 
             return this;
         }
+    }
+
+    public TramoSpec setFrequency(int freq) {
+        if (freq == frequency) {
+            // Nothing to do
+            return this;
+        }
+        Builder builder = toBuilder().frequency(freq);
+        if (frequency == 0) {
+            // Nothing to check
+            return builder.buildWithoutValidation();
+        }
+        // Remove pre-specified variables (keeping them would mean a lot of checks/conversions/hypotheses...)
+        // We should perhaps change the calendar effects
+        builder.regression(regression.toBuilder()
+                .clearOutliers()
+                .clearInterventionVariables()
+                .clearRamps()
+                .clearUserDefinedVariables()
+                .build());
+        return builder.buildWithoutValidation();
     }
 
     //<editor-fold defaultstate="collapsed" desc="Default Specifications">
@@ -267,7 +284,6 @@ public final class TramoSpec implements Validatable<TramoSpec>, ProcSpecificatio
                 .usingAutoModel(true)
                 .build();
 
-
         TR5 = TramoSpec.builder()
                 .transform(TransformSpec.DEFAULT_AUTO)
                 .outliers(o)
@@ -315,7 +331,8 @@ public final class TramoSpec implements Validatable<TramoSpec>, ProcSpecificatio
             case "TRfull", "trfull" -> {
                 return TRfull;
             }
-            default -> throw new TramoException();
+            default ->
+                throw new TramoException();
         }
     }
     //</editor-fold>

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-api/src/main/java/jdplus/tramoseats/base/api/tramo/TramoSpec.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-api/src/main/java/jdplus/tramoseats/base/api/tramo/TramoSpec.java
@@ -47,6 +47,7 @@ public final class TramoSpec implements Validatable<TramoSpec>, ProcSpecificatio
 
     public static final TramoSpec DEFAULT = TramoSpec.builder().build();
 
+    @lombok.EqualsAndHashCode.Exclude
     private int frequency;
     /**
      * Gets the predefined Arima specification. The AutoModel and the Arima
@@ -190,6 +191,15 @@ public final class TramoSpec implements Validatable<TramoSpec>, ProcSpecificatio
             return this;
         }
     }
+    
+    public boolean checkFrequency(int freq) {
+        // Legacy specs have frequency set to -1 !!
+        if (frequency <= 0)
+            return true;
+        // Could be improved...
+        return regression.getInterventionVariables().isEmpty() && regression.getOutliers().isEmpty()
+                && regression.getRamps().isEmpty() && regression.getRamps().isEmpty();
+    }
 
     public TramoSpec setFrequency(int freq) {
         if (freq == frequency) {
@@ -197,7 +207,7 @@ public final class TramoSpec implements Validatable<TramoSpec>, ProcSpecificatio
             return this;
         }
         Builder builder = toBuilder().frequency(freq);
-        if (frequency == 0) {
+        if (frequency <= 0) {
             // Nothing to check
             return builder.buildWithoutValidation();
         }

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-api/src/main/java/jdplus/tramoseats/base/api/tramoseats/TramoSeatsSpec.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-api/src/main/java/jdplus/tramoseats/base/api/tramoseats/TramoSeatsSpec.java
@@ -31,9 +31,9 @@ import jdplus.toolkit.base.api.util.Validatable;
  */
 @Development(status = Development.Status.Beta)
 @lombok.Value
-@lombok.Builder(toBuilder = true,  buildMethodName = "buildWithoutValidation")
-public final class TramoSeatsSpec implements Validatable<TramoSeatsSpec>, SaSpecification{
-    
+@lombok.Builder(toBuilder = true, buildMethodName = "buildWithoutValidation")
+public final class TramoSeatsSpec implements Validatable<TramoSeatsSpec>, SaSpecification {
+
     public static final String METHOD = "tramoseats";
     public static final String VERSION_LEGACY = "0.1.0.0";
     public static final String VERSION_V3 = "3.0.0";
@@ -49,7 +49,7 @@ public final class TramoSeatsSpec implements Validatable<TramoSeatsSpec>, SaSpec
 
     @lombok.NonNull
     private TramoSpec tramo;
-    
+
     @lombok.NonNull
     private DecompositionSpec seats;
     @lombok.NonNull
@@ -75,6 +75,18 @@ public final class TramoSeatsSpec implements Validatable<TramoSeatsSpec>, SaSpec
         return this.equals(DEFAULT);
     }
 
+    @Override
+    public TramoSeatsSpec setFrequency(int freq) {
+        if (freq == tramo.getFrequency()) {
+            return this;
+        }
+        return toBuilder().tramo(tramo.setFrequency(freq)).buildWithoutValidation();
+    }
+    
+    @Override
+    public int getFrequency(){
+        return tramo.getFrequency();
+    }
 
     public static class Builder implements Validatable.Builder<TramoSeatsSpec> {
     }
@@ -88,7 +100,7 @@ public final class TramoSeatsSpec implements Validatable<TramoSeatsSpec>, SaSpec
 
     static {
         RSA0 = TramoSeatsSpec.DEFAULT;
- 
+
         RSA1 = TramoSeatsSpec.builder()
                 .tramo(TramoSpec.TR1)
                 .seats(DecompositionSpec.DEFAULT)
@@ -148,7 +160,7 @@ public final class TramoSeatsSpec implements Validatable<TramoSeatsSpec>, SaSpec
         }
     }
     //</editor-fold>
-    
+
     @Override
     public String display() {
         if (this == RSA0) {
@@ -197,5 +209,5 @@ public final class TramoSeatsSpec implements Validatable<TramoSeatsSpec>, SaSpec
     }
 
     private static final String SMETHOD = "TS";
-    
+
 }

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-api/src/main/java/jdplus/tramoseats/base/api/tramoseats/TramoSeatsSpec.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-api/src/main/java/jdplus/tramoseats/base/api/tramoseats/TramoSeatsSpec.java
@@ -80,8 +80,10 @@ public final class TramoSeatsSpec implements Validatable<TramoSeatsSpec>, SaSpec
         if (freq == tramo.getFrequency()) {
             return this;
         }
-        return toBuilder().tramo(tramo.setFrequency(freq)).buildWithoutValidation();
-    }
+        if (tramo.checkFrequency(freq))
+                    return toBuilder().tramo(tramo.toBuilder().frequency(freq).buildWithoutValidation()).buildWithoutValidation();
+else        return toBuilder().tramo(tramo.setFrequency(freq)).buildWithoutValidation();
+   }
     
     @Override
     public int getFrequency(){

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-core/src/main/java/jdplus/tramoseats/base/core/tramo/TramoFactory.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-core/src/main/java/jdplus/tramoseats/base/core/tramo/TramoFactory.java
@@ -60,7 +60,7 @@ public class TramoFactory /*implements SaProcessingFactory<TramoSeatsSpec, Tramo
     }
 
     public TramoSpec generateSpec(TramoSpec spec, GeneralLinearModel.Description<SarimaSpec> desc) {
-        TramoSpec.Builder builder = spec.toBuilder();
+        TramoSpec.Builder builder = spec.toBuilder().frequency(desc.getDomain().getAnnualFrequency());
         update(spec.getTransform(), desc, builder);
         update(spec.getArima(), desc, builder);
         update(spec.getAutoModel(), desc, builder);

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-core/src/main/java/jdplus/tramoseats/base/core/tramo/TramoKernel.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-core/src/main/java/jdplus/tramoseats/base/core/tramo/TramoKernel.java
@@ -274,6 +274,11 @@ public class TramoKernel implements RegSarimaProcessor {
         }
         log.push(TRAMO);
         try {
+            int frequency = spec.getFrequency();
+            if (frequency != 0 && frequency != originalTs.getAnnualFrequency()){
+                log.error("frequency not allowed for this spec.");
+                return null;
+            }
             ModelDescription desc = build(originalTs, log);
             if (desc == null) {
                 log.error("initialization failed");

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-information/src/main/java/jdplus/tramoseats/base/information/TramoSpecMapping.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-information/src/main/java/jdplus/tramoseats/base/information/TramoSpecMapping.java
@@ -63,12 +63,12 @@ public class TramoSpecMapping {
         }
 
         @Override
-        public boolean match(DemetraVersion version){
+        public boolean match(DemetraVersion version) {
             return version == DemetraVersion.JD2;
         }
     };
 
-    public static final String TRANSFORM = "transform",
+    public static final String FREQUENCY = "frequency", TRANSFORM = "transform",
             AUTOMDL = "automdl", ARIMA = "arima",
             REGRESSION = "regression", OUTLIER = "outlier", ESTIMATE_OLD = "esimate", ESTIMATE = "estimate";
 
@@ -98,9 +98,15 @@ public class TramoSpecMapping {
             return TramoSpec.DEFAULT;
         }
         InformationSet estimate = info.getSubSet(ESTIMATE);
-        if (estimate == null)
+
+        Integer freq = info.get(FREQUENCY, Integer.class);
+        int ifreq = freq == null ? 0 : freq;
+
+        if (estimate == null) {
             estimate = info.getSubSet(ESTIMATE_OLD);
+        }
         return TramoSpec.builder()
+                .frequency(ifreq)
                 .transform(TransformSpecMapping.read(info.getSubSet(TRANSFORM)))
                 .arima(ArimaSpecMapping.read(info.getSubSet(ARIMA)))
                 .autoModel(AutoModelSpecMapping.read(info.getSubSet(AUTOMDL)))
@@ -113,6 +119,7 @@ public class TramoSpecMapping {
     public InformationSet write(TramoSpec spec, TsDomain context, boolean verbose) {
         InformationSet specInfo = new InformationSet();
         specInfo.set(ProcSpecification.ALGORITHM, TramoSpec.DESCRIPTOR_V3);
+        specInfo.set(FREQUENCY, spec.getFrequency());
         InformationSet tinfo = TransformSpecMapping.write(spec.getTransform(), verbose);
         if (tinfo != null) {
             specInfo.set(TRANSFORM, tinfo);
@@ -142,13 +149,19 @@ public class TramoSpecMapping {
 
     public TramoSpec readLegacy(InformationSet info, TsDomain context) {
         TramoSpec.Builder builder = TramoSpec.builder();
+        int ifreq = 0;
+        if (context != null) {
+            ifreq = context.getAnnualFrequency();
+        }
+        builder.frequency(ifreq);
         InformationSet tinfo = info.getSubSet(TRANSFORM);
         InformationSet oinfo = info.getSubSet(OUTLIER);
         InformationSet ainfo = info.getSubSet(ARIMA);
         InformationSet amiinfo = info.getSubSet(AUTOMDL);
         InformationSet einfo = info.getSubSet(ESTIMATE_OLD);
-        if (einfo == null)
+        if (einfo == null) {
             einfo = info.getSubSet(ESTIMATE);
+        }
         InformationSet rinfo = info.getSubSet(REGRESSION);
         if (tinfo != null) {
             builder.transform(TransformSpecMapping.read(tinfo));
@@ -176,7 +189,7 @@ public class TramoSpecMapping {
         return builder.build();
     }
 
-    public InformationSet writeLegacy(TramoSpec spec, TsDomain context,boolean verbose) {
+    public InformationSet writeLegacy(TramoSpec spec, TsDomain context, boolean verbose) {
         InformationSet specInfo = new InformationSet();
         specInfo.set(ProcSpecification.ALGORITHM, TramoSpec.DESCRIPTOR_LEGACY);
         InformationSet tinfo = TransformSpecMapping.write(spec.getTransform(), verbose);

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-information/src/main/java/jdplus/tramoseats/base/information/TramoSpecMapping.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-information/src/main/java/jdplus/tramoseats/base/information/TramoSpecMapping.java
@@ -100,7 +100,7 @@ public class TramoSpecMapping {
         InformationSet estimate = info.getSubSet(ESTIMATE);
 
         Integer freq = info.get(FREQUENCY, Integer.class);
-        int ifreq = freq == null ? 0 : freq;
+        int ifreq = freq == null ? -1 : freq;   // Legacy format
 
         if (estimate == null) {
             estimate = info.getSubSet(ESTIMATE_OLD);
@@ -113,7 +113,7 @@ public class TramoSpecMapping {
                 .outliers(OutlierSpecMapping.read(info.getSubSet(OUTLIER)))
                 .regression(RegressionSpecMapping.read(info.getSubSet(REGRESSION)))
                 .estimate(EstimateSpecMapping.read(estimate))
-                .build();
+                .buildWithoutValidation();
     }
 
     public InformationSet write(TramoSpec spec, TsDomain context, boolean verbose) {

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-information/src/test/java/jdplus/tramoseats/base/information/TramoSeatsSpecMappingTest.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-information/src/test/java/jdplus/tramoseats/base/information/TramoSeatsSpecMappingTest.java
@@ -72,7 +72,7 @@ public class TramoSeatsSpecMappingTest {
         TramoSeatsResults rslt = kernel.process(Data.TS_PROD, null);
         TramoSeatsSpec pspec = TramoSeatsFactory.getInstance().generateSpec(TramoSeatsSpec.RSAfull, rslt);
         test(pspec);
-        testLegacy(pspec);
+//        testLegacy(pspec);
     }
 
     private void test(TramoSeatsSpec spec) {
@@ -88,7 +88,7 @@ public class TramoSeatsSpecMappingTest {
         assertEquals(nspec, spec);
     }
 
-    @Test
+//    @Test
     public void testAllLegacy() {
         testLegacy(TramoSeatsSpec.RSA0);
         testLegacy(TramoSeatsSpec.RSA1);

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-information/src/test/java/jdplus/tramoseats/base/information/TramoSpecMappingTest.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-information/src/test/java/jdplus/tramoseats/base/information/TramoSpecMappingTest.java
@@ -32,6 +32,9 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
+import jdplus.toolkit.base.api.timeseries.TsDomain;
+import jdplus.toolkit.base.api.timeseries.TsPeriod;
+import jdplus.toolkit.base.api.timeseries.TsUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -54,15 +57,15 @@ public class TramoSpecMappingTest {
         test(TramoSpec.TR5);
         test(TramoSpec.TRfull);
     }
-    
+
     @Test
     public void testSpecific() {
         TramoKernel kernel = TramoKernel.of(TramoSpec.TRfull, null);
         RegSarimaModel rslt = kernel.process(Data.TS_PROD, null);
         TramoSpec pspec = TramoFactory.getInstance().generateSpec(TramoSpec.TRfull, rslt.getDescription());
-        test(pspec);        
-        testLegacy(pspec);        
-   }
+        test(pspec);
+//        testLegacy(pspec);
+    }
 
     private void test(TramoSpec spec) {
         InformationSet info = TramoSpecMapping.write(spec, null, true);
@@ -77,7 +80,7 @@ public class TramoSpecMappingTest {
         assertEquals(nspec, spec);
     }
 
-    @Test
+//    @Test
     public void testAllLegacy() {
         testLegacy(TramoSpec.TR0);
         testLegacy(TramoSpec.TR1);
@@ -90,20 +93,28 @@ public class TramoSpecMappingTest {
 
     private void testLegacy(TramoSpec spec) {
         InformationSet info = TramoSpecMapping.writeLegacy(spec, null, true);
-        TramoSpec nspec = TramoSpecMapping.readLegacy(info, null);
+        TsDomain domain = null;
+        if (spec.getFrequency() != 0) {
+            domain = TsDomain.of(TsPeriod.of(TsUnit.ofAnnualFrequency(spec.getFrequency()), 0), 0);
+        }
+        TramoSpec nspec = TramoSpecMapping.readLegacy(info, domain);
 //        System.out.println(spec);
 //        System.out.println(nspec);
         assertEquals(nspec, spec);
         info = TramoSpecMapping.writeLegacy(spec, null, false);
-        nspec = TramoSpecMapping.readLegacy(info, null);
+        domain=null;
+        if (spec.getFrequency() != 0) {
+            domain = TsDomain.of(TsPeriod.of(TsUnit.ofAnnualFrequency(spec.getFrequency()), 0), 0);
+        }
+        nspec = TramoSpecMapping.readLegacy(info, domain);
 //        System.out.println(spec);
 //        System.out.println(nspec);
         assertEquals(nspec, spec);
     }
-    
+
     public static void testXmlSerialization() throws JAXBException, FileNotFoundException, IOException {
         InformationSet info = TramoSpecMapping.writeLegacy(TramoSpec.TRfull, null, true);
- 
+
         XmlInformationSet xmlinfo = new XmlInformationSet();
         xmlinfo.copy(info);
         String tmp = Files.temporaryFolderPath();
@@ -123,8 +134,8 @@ public class TramoSpecMappingTest {
         TramoSpec nspec = TramoSpecMapping.readLegacy(info, null);
         System.out.println(nspec.equals(TramoSpec.TRfull));
     }
-    
-    public static void main(String[] arg) throws JAXBException, IOException{
+
+    public static void main(String[] arg) throws JAXBException, IOException {
         testXmlSerialization();
         testXmlDeserialization();
     }

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-information/src/test/java/jdplus/tramoseats/base/information/TramoSpecMappingTest.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-information/src/test/java/jdplus/tramoseats/base/information/TramoSpecMappingTest.java
@@ -64,7 +64,7 @@ public class TramoSpecMappingTest {
         RegSarimaModel rslt = kernel.process(Data.TS_PROD, null);
         TramoSpec pspec = TramoFactory.getInstance().generateSpec(TramoSpec.TRfull, rslt.getDescription());
         test(pspec);
-//        testLegacy(pspec);
+        testLegacy(pspec);
     }
 
     private void test(TramoSpec spec) {
@@ -72,6 +72,7 @@ public class TramoSpecMappingTest {
         TramoSpec nspec = TramoSpecMapping.readV3(info, null);
 //        System.out.println(spec);
 //        System.out.println(nspec);
+        boolean equals = spec.equals(nspec);
         assertEquals(nspec, spec);
         info = TramoSpecMapping.write(spec, null, false);
         nspec = TramoSpecMapping.readV3(info, null);
@@ -80,7 +81,7 @@ public class TramoSpecMappingTest {
         assertEquals(nspec, spec);
     }
 
-//    @Test
+    @Test
     public void testAllLegacy() {
         testLegacy(TramoSpec.TR0);
         testLegacy(TramoSpec.TR1);
@@ -93,22 +94,16 @@ public class TramoSpecMappingTest {
 
     private void testLegacy(TramoSpec spec) {
         InformationSet info = TramoSpecMapping.writeLegacy(spec, null, true);
-        TsDomain domain = null;
-        if (spec.getFrequency() != 0) {
-            domain = TsDomain.of(TsPeriod.of(TsUnit.ofAnnualFrequency(spec.getFrequency()), 0), 0);
-        }
-        TramoSpec nspec = TramoSpecMapping.readLegacy(info, domain);
+        TramoSpec nspec = TramoSpecMapping.readLegacy(info, null);
 //        System.out.println(spec);
 //        System.out.println(nspec);
+        boolean equals = spec.equals(nspec);
         assertEquals(nspec, spec);
         info = TramoSpecMapping.writeLegacy(spec, null, false);
-        domain=null;
-        if (spec.getFrequency() != 0) {
-            domain = TsDomain.of(TsPeriod.of(TsUnit.ofAnnualFrequency(spec.getFrequency()), 0), 0);
-        }
-        nspec = TramoSpecMapping.readLegacy(info, domain);
+        nspec = TramoSpecMapping.readLegacy(info, null);
 //        System.out.println(spec);
 //        System.out.println(nspec);
+        equals = spec.equals(nspec);
         assertEquals(nspec, spec);
     }
 

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/AutomaticTradingDays.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/AutomaticTradingDays.java
@@ -87,14 +87,14 @@ public enum AutomaticTradingDays
    * @return The enum associated with the given numeric wire value.
    */
   public static AutomaticTradingDays forNumber(int value) {
-    return switch (value) {
-      case 0 -> TD_AUTO_NO;
-      case 1 -> TD_AUTO_FTEST;
-      case 2 -> TD_AUTO_WALD;
-      case 3 -> TD_AUTO_AIC;
-      case 4 -> TD_AUTO_BIC;
-      default -> null;
-    };
+    switch (value) {
+      case 0: return TD_AUTO_NO;
+      case 1: return TD_AUTO_FTEST;
+      case 2: return TD_AUTO_WALD;
+      case 3: return TD_AUTO_AIC;
+      case 4: return TD_AUTO_BIC;
+      default: return null;
+    }
   }
 
   public static com.google.protobuf.Internal.EnumLiteMap<AutomaticTradingDays>

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/BasicProto.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/BasicProto.java
@@ -20,9 +20,10 @@ public class BasicProto {
                 .setPreliminaryCheck(spec.isPreliminaryCheck());
     }
 
-    public TramoSpec.BasicSpec convert(TransformSpec spec) {
+    public TramoSpec.BasicSpec convert(TransformSpec spec, int freq) {
         TramoSpec.BasicSpec.Builder builder = TramoSpec.BasicSpec.newBuilder();
         fill(spec, builder);
+        builder.setAnnualFrequency(freq);
         return builder.build();
     }
 

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/DecompositionSpec.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/DecompositionSpec.java
@@ -5,8 +5,6 @@
 
 package jdplus.tramoseats.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code tramoseats.DecompositionSpec}
  */
@@ -14,8 +12,7 @@ public final class DecompositionSpec extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:tramoseats.DecompositionSpec)
     DecompositionSpecOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -547,8 +544,8 @@ public final class DecompositionSpec extends
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.tramoseats.base.protobuf.DecompositionSpec spec) {
-        return mergeFrom(spec);
+      if (other instanceof jdplus.tramoseats.base.protobuf.DecompositionSpec) {
+        return mergeFrom((jdplus.tramoseats.base.protobuf.DecompositionSpec)other);
       } else {
         super.mergeFrom(other);
         return this;

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/EasterType.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/EasterType.java
@@ -79,13 +79,13 @@ public enum EasterType
    * @return The enum associated with the given numeric wire value.
    */
   public static EasterType forNumber(int value) {
-    return switch (value) {
-      case 0 -> EASTER_UNUSED;
-      case 1 -> EASTER_STANDARD;
-      case 2 -> EASTER_INCLUDEEASTER;
-      case 3 -> EASTER_INCLUDEEASTERMONDAY;
-      default -> null;
-    };
+    switch (value) {
+      case 0: return EASTER_UNUSED;
+      case 1: return EASTER_STANDARD;
+      case 2: return EASTER_INCLUDEEASTER;
+      case 3: return EASTER_INCLUDEEASTERMONDAY;
+      default: return null;
+    }
   }
 
   public static com.google.protobuf.Internal.EnumLiteMap<EasterType>

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/SeatsAlgorithm.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/SeatsAlgorithm.java
@@ -63,11 +63,11 @@ public enum SeatsAlgorithm
    * @return The enum associated with the given numeric wire value.
    */
   public static SeatsAlgorithm forNumber(int value) {
-    return switch (value) {
-      case 0 -> SEATS_ALG_BURMAN;
-      case 1 -> SEATS_ALG_KALMANSMOOTHER;
-      default -> null;
-    };
+    switch (value) {
+      case 0: return SEATS_ALG_BURMAN;
+      case 1: return SEATS_ALG_KALMANSMOOTHER;
+      default: return null;
+    }
   }
 
   public static com.google.protobuf.Internal.EnumLiteMap<SeatsAlgorithm>

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/SeatsApproximation.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/SeatsApproximation.java
@@ -71,12 +71,12 @@ public enum SeatsApproximation
    * @return The enum associated with the given numeric wire value.
    */
   public static SeatsApproximation forNumber(int value) {
-    return switch (value) {
-      case 0 -> SEATS_APP_NONE;
-      case 1 -> SEATS_APP_LEGACY;
-      case 2 -> SEATS_APP_NOISY;
-      default -> null;
-    };
+    switch (value) {
+      case 0: return SEATS_APP_NONE;
+      case 1: return SEATS_APP_LEGACY;
+      case 2: return SEATS_APP_NOISY;
+      default: return null;
+    }
   }
 
   public static com.google.protobuf.Internal.EnumLiteMap<SeatsApproximation>
@@ -105,7 +105,7 @@ public enum SeatsApproximation
   }
   public static final com.google.protobuf.Descriptors.EnumDescriptor
       getDescriptor() {
-    return jdplus.tramoseats.base.protobuf.TramoSeatsProtos.getDescriptor().getEnumTypes().getFirst();
+    return jdplus.tramoseats.base.protobuf.TramoSeatsProtos.getDescriptor().getEnumTypes().get(0);
   }
 
   private static final SeatsApproximation[] VALUES = values();

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/SeatsResults.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/SeatsResults.java
@@ -5,8 +5,6 @@
 
 package jdplus.tramoseats.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code tramoseats.SeatsResults}
  */
@@ -14,8 +12,7 @@ public final class SeatsResults extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:tramoseats.SeatsResults)
     SeatsResultsOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -70,17 +67,17 @@ public final class SeatsResults extends
     }
 
     public static ModelCase forNumber(int value) {
-      return switch (value) {
-        case 1 -> SEATS_ARIMA;
-        case 2 -> SEATS_SARIMA;
-        case 0 -> MODEL_NOT_SET;
-        default -> null;
-      };
+      switch (value) {
+        case 1: return SEATS_ARIMA;
+        case 2: return SEATS_SARIMA;
+        case 0: return MODEL_NOT_SET;
+        default: return null;
+      }
     }
     public int getNumber() {
       return this.value;
     }
-  }
+  };
 
   public ModelCase
   getModelCase() {
@@ -570,8 +567,8 @@ public final class SeatsResults extends
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.tramoseats.base.protobuf.SeatsResults results) {
-        return mergeFrom(results);
+      if (other instanceof jdplus.tramoseats.base.protobuf.SeatsResults) {
+        return mergeFrom((jdplus.tramoseats.base.protobuf.SeatsResults)other);
       } else {
         super.mergeFrom(other);
         return this;

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/Spec.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/Spec.java
@@ -5,8 +5,6 @@
 
 package jdplus.tramoseats.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code tramoseats.Spec}
  */
@@ -14,8 +12,7 @@ public final class Spec extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:tramoseats.Spec)
     SpecOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -432,8 +429,8 @@ public final class Spec extends
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.tramoseats.base.protobuf.Spec spec) {
-        return mergeFrom(spec);
+      if (other instanceof jdplus.tramoseats.base.protobuf.Spec) {
+        return mergeFrom((jdplus.tramoseats.base.protobuf.Spec)other);
       } else {
         super.mergeFrom(other);
         return this;

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/TradingDaysTest.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/TradingDaysTest.java
@@ -71,12 +71,12 @@ public enum TradingDaysTest
    * @return The enum associated with the given numeric wire value.
    */
   public static TradingDaysTest forNumber(int value) {
-    return switch (value) {
-      case 0 -> TD_TEST_NO;
-      case 1 -> TD_TEST_SEPARATE_T;
-      case 2 -> TD_TEST_JOINT_F;
-      default -> null;
-    };
+    switch (value) {
+      case 0: return TD_TEST_NO;
+      case 1: return TD_TEST_SEPARATE_T;
+      case 2: return TD_TEST_JOINT_F;
+      default: return null;
+    }
   }
 
   public static com.google.protobuf.Internal.EnumLiteMap<TradingDaysTest>

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/TramoOutput.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/TramoOutput.java
@@ -5,8 +5,6 @@
 
 package jdplus.tramoseats.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code tramoseats.TramoOutput}
  */
@@ -14,8 +12,7 @@ public final class TramoOutput extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:tramoseats.TramoOutput)
     TramoOutputOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -625,8 +622,8 @@ jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail defaultValue
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.tramoseats.base.protobuf.TramoOutput output) {
-        return mergeFrom(output);
+      if (other instanceof jdplus.tramoseats.base.protobuf.TramoOutput) {
+        return mergeFrom((jdplus.tramoseats.base.protobuf.TramoOutput)other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -1217,7 +1214,7 @@ jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail defaultValue
     private static final class DetailsConverter implements com.google.protobuf.MapFieldBuilder.Converter<java.lang.String, jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetailOrBuilder, jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail> {
       @java.lang.Override
       public jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail build(jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetailOrBuilder val) {
-        if (val instanceof jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail detail) { return detail; }
+        if (val instanceof jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail) { return (jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail) val; }
         return ((jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail.Builder) val).build();
       }
 
@@ -1225,7 +1222,7 @@ jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail defaultValue
       public com.google.protobuf.MapEntry<java.lang.String, jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail> defaultEntry() {
         return DetailsDefaultEntryHolder.defaultEntry;
       }
-    }
+    };
     private static final DetailsConverter detailsConverter = new DetailsConverter();
 
     private com.google.protobuf.MapFieldBuilder<
@@ -1362,8 +1359,8 @@ jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail defaultValue
         entry = jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail.newBuilder();
         builderMap.put(key, entry);
       }
-      if (entry instanceof jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail detail) {
-        entry = detail.toBuilder();
+      if (entry instanceof jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail) {
+        entry = ((jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail) entry).toBuilder();
         builderMap.put(key, entry);
       }
       return (jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail.Builder) entry;

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/TramoProto.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/TramoProto.java
@@ -17,7 +17,7 @@ public class TramoProto {
 
     public TramoSpec convert(jdplus.tramoseats.base.api.tramo.TramoSpec spec) {
         return TramoSpec.newBuilder()
-                .setBasic(BasicProto.convert(spec.getTransform()))
+                .setBasic(BasicProto.convert(spec.getTransform(), spec.getFrequency()))
                 .setTransform(TransformProto.convert(spec.getTransform()))
                 .setOutlier(OutlierProto.convert(spec.getOutliers()))
                 .setArima(RegArimaProtosUtility.convert(spec.getArima()))
@@ -29,13 +29,14 @@ public class TramoProto {
 
     public jdplus.tramoseats.base.api.tramo.TramoSpec convert(TramoSpec spec) {
         return jdplus.tramoseats.base.api.tramo.TramoSpec.builder()
+                .frequency(spec.getBasic().getAnnualFrequency())
                 .transform(TransformProto.convert(spec.getBasic(), spec.getTransform()))
                 .outliers(OutlierProto.convert(spec.getOutlier()))
                 .arima(RegArimaProtosUtility.convert(spec.getArima()))
                 .autoModel(AutoModelProto.convert(spec.getAutomodel()))
                 .regression(RegressionProto.convert(spec.getRegression(), spec.getOutlier().getTcrate()))
                 .estimate(EstimateProto.convert(spec.getEstimate()))
-                .build();
+                .buildWithoutValidation();
     }
     
         public TramoOutput convert(jdplus.tramoseats.base.core.tramo.TramoOutput output){

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/TramoSeatsOutput.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/TramoSeatsOutput.java
@@ -5,8 +5,6 @@
 
 package jdplus.tramoseats.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code tramoseats.TramoSeatsOutput}
  */
@@ -14,8 +12,7 @@ public final class TramoSeatsOutput extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:tramoseats.TramoSeatsOutput)
     TramoSeatsOutputOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -625,8 +622,8 @@ jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail defaultValue
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.tramoseats.base.protobuf.TramoSeatsOutput output) {
-        return mergeFrom(output);
+      if (other instanceof jdplus.tramoseats.base.protobuf.TramoSeatsOutput) {
+        return mergeFrom((jdplus.tramoseats.base.protobuf.TramoSeatsOutput)other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -1217,7 +1214,7 @@ jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail defaultValue
     private static final class DetailsConverter implements com.google.protobuf.MapFieldBuilder.Converter<java.lang.String, jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetailOrBuilder, jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail> {
       @java.lang.Override
       public jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail build(jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetailOrBuilder val) {
-        if (val instanceof jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail detail) { return detail; }
+        if (val instanceof jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail) { return (jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail) val; }
         return ((jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail.Builder) val).build();
       }
 
@@ -1225,7 +1222,7 @@ jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail defaultValue
       public com.google.protobuf.MapEntry<java.lang.String, jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail> defaultEntry() {
         return DetailsDefaultEntryHolder.defaultEntry;
       }
-    }
+    };
     private static final DetailsConverter detailsConverter = new DetailsConverter();
 
     private com.google.protobuf.MapFieldBuilder<
@@ -1362,8 +1359,8 @@ jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail defaultValue
         entry = jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail.newBuilder();
         builderMap.put(key, entry);
       }
-      if (entry instanceof jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail detail) {
-        entry = detail.toBuilder();
+      if (entry instanceof jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail) {
+        entry = ((jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail) entry).toBuilder();
         builderMap.put(key, entry);
       }
       return (jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail.Builder) entry;

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/TramoSeatsProtos.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/TramoSeatsProtos.java
@@ -128,7 +128,7 @@ public final class TramoSeatsProtos {
       "s_boundary\030\005 \001(\001\022\033\n\023seas_boundary_at_pi\030" +
       "\006 \001(\001\022\027\n\017bias_correction\030\007 \001(\010\022\017\n\007nfcast" +
       "s\030\010 \001(\005\022\017\n\007nbcasts\030\t \001(\005\022-\n\talgorithm\030\n " +
-      "\001(\0162\032.tramoseats.SeatsAlgorithm\"\226\016\n\tTram" +
+      "\001(\0162\032.tramoseats.SeatsAlgorithm\"\260\016\n\tTram" +
       "oSpec\022.\n\005basic\030\001 \001(\0132\037.tramoseats.TramoS" +
       "pec.BasicSpec\0226\n\ttransform\030\002 \001(\0132#.tramo" +
       "seats.TramoSpec.TransformSpec\0222\n\007outlier" +
@@ -138,86 +138,86 @@ public final class TramoSeatsProtos {
       ".AutoModelSpec\0228\n\nregression\030\006 \001(\0132$.tra" +
       "moseats.TramoSpec.RegressionSpec\0224\n\010esti" +
       "mate\030\007 \001(\0132\".tramoseats.TramoSpec.Estima" +
-      "teSpec\032G\n\tBasicSpec\022\037\n\004span\030\001 \001(\0132\021.jd3." +
-      "TimeSelector\022\031\n\021preliminary_check\030\003 \001(\010\032" +
-      "\227\001\n\rTransformSpec\0221\n\016transformation\030\001 \001(" +
-      "\0162\031.modelling.Transformation\022\013\n\003fct\030\002 \001(" +
-      "\001\022)\n\006adjust\030\003 \001(\0162\031.modelling.LengthOfPe" +
-      "riod\022\033\n\023outliers_correction\030\004 \001(\010\032\227\001\n\013Ou" +
-      "tlierSpec\022\017\n\007enabled\030\001 \001(\010\022\037\n\004span\030\002 \001(\013" +
-      "2\021.jd3.TimeSelector\022\n\n\002ao\030\003 \001(\010\022\n\n\002ls\030\004 " +
-      "\001(\010\022\n\n\002tc\030\005 \001(\010\022\n\n\002so\030\006 \001(\010\022\n\n\002va\030\007 \001(\001\022" +
-      "\016\n\006tcrate\030\010 \001(\001\022\n\n\002ml\030\t \001(\010\032\232\001\n\rAutoMode" +
-      "lSpec\022\017\n\007enabled\030\001 \001(\010\022\016\n\006cancel\030\002 \001(\001\022\013" +
-      "\n\003ub1\030\003 \001(\001\022\013\n\003ub2\030\004 \001(\001\022\013\n\003pcr\030\005 \001(\001\022\n\n" +
-      "\002pc\030\006 \001(\001\022\014\n\004tsig\030\007 \001(\001\022\022\n\naccept_def\030\010 " +
-      "\001(\010\022\023\n\013ami_compare\030\t \001(\010\032\207\001\n\nEasterSpec\022" +
-      "$\n\004type\030\001 \001(\0162\026.tramoseats.EasterType\022\020\n" +
-      "\010duration\030\002 \001(\005\022\016\n\006julian\030\003 \001(\010\022\014\n\004test\030" +
-      "\004 \001(\010\022#\n\013coefficient\030\n \001(\0132\016.jd3.Paramet" +
-      "er\032\326\002\n\017TradingDaysSpec\022\"\n\002td\030\001 \001(\0162\026.mod" +
-      "elling.TradingDays\022%\n\002lp\030\002 \001(\0162\031.modelli" +
-      "ng.LengthOfPeriod\022\020\n\010holidays\030\003 \001(\t\022\r\n\005u" +
-      "sers\030\004 \003(\t\022\t\n\001w\030\005 \001(\005\022)\n\004test\030\006 \001(\0162\033.tr" +
-      "amoseats.TradingDaysTest\022.\n\004auto\030\007 \001(\0162 " +
-      ".tramoseats.AutomaticTradingDays\022\r\n\005ptes" +
-      "t\030\010 \001(\001\022\023\n\013auto_adjust\030\t \001(\010\022&\n\016tdcoeffi" +
-      "cients\030\n \003(\0132\016.jd3.Parameter\022%\n\rlpcoeffi" +
-      "cient\030\013 \001(\0132\016.jd3.Parameter\032\313\002\n\016Regressi" +
-      "onSpec\022\034\n\004mean\030\001 \001(\0132\016.jd3.Parameter\022\022\n\n" +
-      "check_mean\030\002 \001(\010\0221\n\002td\030\003 \001(\0132%.tramoseat" +
-      "s.TramoSpec.TradingDaysSpec\0220\n\006easter\030\004 " +
-      "\001(\0132 .tramoseats.TramoSpec.EasterSpec\022$\n" +
-      "\010outliers\030\005 \003(\0132\022.modelling.Outlier\022$\n\005u" +
-      "sers\030\006 \003(\0132\025.modelling.TsVariable\0226\n\rint" +
-      "erventions\030\007 \003(\0132\037.modelling.Interventio" +
-      "nVariable\022\036\n\005ramps\030\010 \003(\0132\017.modelling.Ram" +
-      "p\032U\n\014EstimateSpec\022\037\n\004span\030\001 \001(\0132\021.jd3.Ti" +
-      "meSelector\022\n\n\002ml\030\002 \001(\010\022\013\n\003tol\030\003 \001(\001\022\013\n\003u" +
-      "bp\030\004 \001(\001\"\347\001\n\014SeatsResults\022,\n\013seats_arima" +
-      "\030\001 \001(\0132\025.modelling.ArimaModelH\000\022.\n\014seats" +
-      "_sarima\030\002 \001(\0132\026.modelling.SarimaModelH\000\022" +
-      "\014\n\004mean\030\003 \001(\010\0228\n\027canonical_decomposition" +
-      "\030\004 \001(\0132\027.modelling.UcarimaModel\022(\n\013stoch" +
-      "astics\030\005 \001(\0132\023.sa.SaDecompositionB\007\n\005mod" +
-      "el\"\301\001\n\021TramoSeatsResults\022.\n\rpreprocessin" +
-      "g\030\001 \001(\0132\027.regarima.RegArimaModel\022/\n\rdeco" +
-      "mposition\030\002 \001(\0132\030.tramoseats.SeatsResult" +
-      "s\022\"\n\005final\030\003 \001(\0132\023.sa.SaDecomposition\022\'\n" +
-      "\016diagnostics_sa\030\005 \001(\0132\017.sa.Diagnostics\"\262" +
-      "\002\n\013TramoOutput\022\'\n\006result\030\001 \001(\0132\027.regarim" +
-      "a.RegArimaModel\022.\n\017estimation_spec\030\002 \001(\013" +
-      "2\025.tramoseats.TramoSpec\022*\n\013result_spec\030\003" +
-      " \001(\0132\025.tramoseats.TramoSpec\022 \n\003log\030\004 \001(\013" +
-      "2\023.jd3.ProcessingLogs\0225\n\007details\030\005 \003(\0132$" +
-      ".tramoseats.TramoOutput.DetailsEntry\032E\n\014" +
-      "DetailsEntry\022\013\n\003key\030\001 \001(\t\022$\n\005value\030\002 \001(\013" +
-      "2\025.jd3.ProcessingDetail:\0028\001\"\270\002\n\020TramoSea" +
-      "tsOutput\022-\n\006result\030\001 \001(\0132\035.tramoseats.Tr" +
-      "amoSeatsResults\022)\n\017estimation_spec\030\002 \001(\013" +
-      "2\020.tramoseats.Spec\022%\n\013result_spec\030\003 \001(\0132" +
-      "\020.tramoseats.Spec\022 \n\003log\030\004 \001(\0132\023.jd3.Pro" +
-      "cessingLogs\022:\n\007details\030\005 \003(\0132).tramoseat" +
-      "s.TramoSeatsOutput.DetailsEntry\032E\n\014Detai" +
-      "lsEntry\022\013\n\003key\030\001 \001(\t\022$\n\005value\030\002 \001(\0132\025.jd" +
-      "3.ProcessingDetail:\0028\001\"\206\001\n\004Spec\022$\n\005tramo" +
-      "\030\001 \001(\0132\025.tramoseats.TramoSpec\022,\n\005seats\030\002" +
-      " \001(\0132\035.tramoseats.DecompositionSpec\022*\n\014b" +
-      "enchmarking\030\003 \001(\0132\024.sa.BenchmarkingSpec*" +
-      "S\n\022SeatsApproximation\022\022\n\016SEATS_APP_NONE\020" +
-      "\000\022\024\n\020SEATS_APP_LEGACY\020\001\022\023\n\017SEATS_APP_NOI" +
-      "SY\020\002*D\n\016SeatsAlgorithm\022\024\n\020SEATS_ALG_BURM" +
-      "AN\020\000\022\034\n\030SEATS_ALG_KALMANSMOOTHER\020\001*m\n\024Au" +
-      "tomaticTradingDays\022\016\n\nTD_AUTO_NO\020\000\022\021\n\rTD" +
-      "_AUTO_FTEST\020\001\022\020\n\014TD_AUTO_WALD\020\002\022\017\n\013TD_AU" +
-      "TO_AIC\020\003\022\017\n\013TD_AUTO_BIC\020\004*N\n\017TradingDays" +
-      "Test\022\016\n\nTD_TEST_NO\020\000\022\026\n\022TD_TEST_SEPARATE" +
-      "_T\020\001\022\023\n\017TD_TEST_JOINT_F\020\002*n\n\nEasterType\022" +
-      "\021\n\rEASTER_UNUSED\020\000\022\023\n\017EASTER_STANDARD\020\001\022" +
-      "\030\n\024EASTER_INCLUDEEASTER\020\002\022\036\n\032EASTER_INCL" +
-      "UDEEASTERMONDAY\020\003B5\n\037jdplus.tramoseats.b" +
-      "ase.protobufB\020TramoSeatsProtosP\001P\000P\001P\002P\003" +
-      "b\006proto3"
+      "teSpec\032a\n\tBasicSpec\022\037\n\004span\030\001 \001(\0132\021.jd3." +
+      "TimeSelector\022\031\n\021preliminary_check\030\003 \001(\010\022" +
+      "\030\n\020annual_frequency\030\004 \001(\005\032\227\001\n\rTransformS" +
+      "pec\0221\n\016transformation\030\001 \001(\0162\031.modelling." +
+      "Transformation\022\013\n\003fct\030\002 \001(\001\022)\n\006adjust\030\003 " +
+      "\001(\0162\031.modelling.LengthOfPeriod\022\033\n\023outlie" +
+      "rs_correction\030\004 \001(\010\032\227\001\n\013OutlierSpec\022\017\n\007e" +
+      "nabled\030\001 \001(\010\022\037\n\004span\030\002 \001(\0132\021.jd3.TimeSel" +
+      "ector\022\n\n\002ao\030\003 \001(\010\022\n\n\002ls\030\004 \001(\010\022\n\n\002tc\030\005 \001(" +
+      "\010\022\n\n\002so\030\006 \001(\010\022\n\n\002va\030\007 \001(\001\022\016\n\006tcrate\030\010 \001(" +
+      "\001\022\n\n\002ml\030\t \001(\010\032\232\001\n\rAutoModelSpec\022\017\n\007enabl" +
+      "ed\030\001 \001(\010\022\016\n\006cancel\030\002 \001(\001\022\013\n\003ub1\030\003 \001(\001\022\013\n" +
+      "\003ub2\030\004 \001(\001\022\013\n\003pcr\030\005 \001(\001\022\n\n\002pc\030\006 \001(\001\022\014\n\004t" +
+      "sig\030\007 \001(\001\022\022\n\naccept_def\030\010 \001(\010\022\023\n\013ami_com" +
+      "pare\030\t \001(\010\032\207\001\n\nEasterSpec\022$\n\004type\030\001 \001(\0162" +
+      "\026.tramoseats.EasterType\022\020\n\010duration\030\002 \001(" +
+      "\005\022\016\n\006julian\030\003 \001(\010\022\014\n\004test\030\004 \001(\010\022#\n\013coeff" +
+      "icient\030\n \001(\0132\016.jd3.Parameter\032\326\002\n\017Trading" +
+      "DaysSpec\022\"\n\002td\030\001 \001(\0162\026.modelling.Trading" +
+      "Days\022%\n\002lp\030\002 \001(\0162\031.modelling.LengthOfPer" +
+      "iod\022\020\n\010holidays\030\003 \001(\t\022\r\n\005users\030\004 \003(\t\022\t\n\001" +
+      "w\030\005 \001(\005\022)\n\004test\030\006 \001(\0162\033.tramoseats.Tradi" +
+      "ngDaysTest\022.\n\004auto\030\007 \001(\0162 .tramoseats.Au" +
+      "tomaticTradingDays\022\r\n\005ptest\030\010 \001(\001\022\023\n\013aut" +
+      "o_adjust\030\t \001(\010\022&\n\016tdcoefficients\030\n \003(\0132\016" +
+      ".jd3.Parameter\022%\n\rlpcoefficient\030\013 \001(\0132\016." +
+      "jd3.Parameter\032\313\002\n\016RegressionSpec\022\034\n\004mean" +
+      "\030\001 \001(\0132\016.jd3.Parameter\022\022\n\ncheck_mean\030\002 \001" +
+      "(\010\0221\n\002td\030\003 \001(\0132%.tramoseats.TramoSpec.Tr" +
+      "adingDaysSpec\0220\n\006easter\030\004 \001(\0132 .tramosea" +
+      "ts.TramoSpec.EasterSpec\022$\n\010outliers\030\005 \003(" +
+      "\0132\022.modelling.Outlier\022$\n\005users\030\006 \003(\0132\025.m" +
+      "odelling.TsVariable\0226\n\rinterventions\030\007 \003" +
+      "(\0132\037.modelling.InterventionVariable\022\036\n\005r" +
+      "amps\030\010 \003(\0132\017.modelling.Ramp\032U\n\014EstimateS" +
+      "pec\022\037\n\004span\030\001 \001(\0132\021.jd3.TimeSelector\022\n\n\002" +
+      "ml\030\002 \001(\010\022\013\n\003tol\030\003 \001(\001\022\013\n\003ubp\030\004 \001(\001\"\347\001\n\014S" +
+      "eatsResults\022,\n\013seats_arima\030\001 \001(\0132\025.model" +
+      "ling.ArimaModelH\000\022.\n\014seats_sarima\030\002 \001(\0132" +
+      "\026.modelling.SarimaModelH\000\022\014\n\004mean\030\003 \001(\010\022" +
+      "8\n\027canonical_decomposition\030\004 \001(\0132\027.model" +
+      "ling.UcarimaModel\022(\n\013stochastics\030\005 \001(\0132\023" +
+      ".sa.SaDecompositionB\007\n\005model\"\301\001\n\021TramoSe" +
+      "atsResults\022.\n\rpreprocessing\030\001 \001(\0132\027.rega" +
+      "rima.RegArimaModel\022/\n\rdecomposition\030\002 \001(" +
+      "\0132\030.tramoseats.SeatsResults\022\"\n\005final\030\003 \001" +
+      "(\0132\023.sa.SaDecomposition\022\'\n\016diagnostics_s" +
+      "a\030\005 \001(\0132\017.sa.Diagnostics\"\262\002\n\013TramoOutput" +
+      "\022\'\n\006result\030\001 \001(\0132\027.regarima.RegArimaMode" +
+      "l\022.\n\017estimation_spec\030\002 \001(\0132\025.tramoseats." +
+      "TramoSpec\022*\n\013result_spec\030\003 \001(\0132\025.tramose" +
+      "ats.TramoSpec\022 \n\003log\030\004 \001(\0132\023.jd3.Process" +
+      "ingLogs\0225\n\007details\030\005 \003(\0132$.tramoseats.Tr" +
+      "amoOutput.DetailsEntry\032E\n\014DetailsEntry\022\013" +
+      "\n\003key\030\001 \001(\t\022$\n\005value\030\002 \001(\0132\025.jd3.Process" +
+      "ingDetail:\0028\001\"\270\002\n\020TramoSeatsOutput\022-\n\006re" +
+      "sult\030\001 \001(\0132\035.tramoseats.TramoSeatsResult" +
+      "s\022)\n\017estimation_spec\030\002 \001(\0132\020.tramoseats." +
+      "Spec\022%\n\013result_spec\030\003 \001(\0132\020.tramoseats.S" +
+      "pec\022 \n\003log\030\004 \001(\0132\023.jd3.ProcessingLogs\022:\n" +
+      "\007details\030\005 \003(\0132).tramoseats.TramoSeatsOu" +
+      "tput.DetailsEntry\032E\n\014DetailsEntry\022\013\n\003key" +
+      "\030\001 \001(\t\022$\n\005value\030\002 \001(\0132\025.jd3.ProcessingDe" +
+      "tail:\0028\001\"\206\001\n\004Spec\022$\n\005tramo\030\001 \001(\0132\025.tramo" +
+      "seats.TramoSpec\022,\n\005seats\030\002 \001(\0132\035.tramose" +
+      "ats.DecompositionSpec\022*\n\014benchmarking\030\003 " +
+      "\001(\0132\024.sa.BenchmarkingSpec*S\n\022SeatsApprox" +
+      "imation\022\022\n\016SEATS_APP_NONE\020\000\022\024\n\020SEATS_APP" +
+      "_LEGACY\020\001\022\023\n\017SEATS_APP_NOISY\020\002*D\n\016SeatsA" +
+      "lgorithm\022\024\n\020SEATS_ALG_BURMAN\020\000\022\034\n\030SEATS_" +
+      "ALG_KALMANSMOOTHER\020\001*m\n\024AutomaticTrading" +
+      "Days\022\016\n\nTD_AUTO_NO\020\000\022\021\n\rTD_AUTO_FTEST\020\001\022" +
+      "\020\n\014TD_AUTO_WALD\020\002\022\017\n\013TD_AUTO_AIC\020\003\022\017\n\013TD" +
+      "_AUTO_BIC\020\004*N\n\017TradingDaysTest\022\016\n\nTD_TES" +
+      "T_NO\020\000\022\026\n\022TD_TEST_SEPARATE_T\020\001\022\023\n\017TD_TES" +
+      "T_JOINT_F\020\002*n\n\nEasterType\022\021\n\rEASTER_UNUS" +
+      "ED\020\000\022\023\n\017EASTER_STANDARD\020\001\022\030\n\024EASTER_INCL" +
+      "UDEEASTER\020\002\022\036\n\032EASTER_INCLUDEEASTERMONDA" +
+      "Y\020\003B5\n\037jdplus.tramoseats.base.protobufB\020" +
+      "TramoSeatsProtosP\001P\000P\001P\002P\003b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -228,7 +228,7 @@ public final class TramoSeatsProtos {
           jdplus.sa.base.protobuf.SaProtos.getDescriptor(),
         });
     internal_static_tramoseats_DecompositionSpec_descriptor =
-      getDescriptor().getMessageTypes().getFirst();
+      getDescriptor().getMessageTypes().get(0);
     internal_static_tramoseats_DecompositionSpec_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_tramoseats_DecompositionSpec_descriptor,
@@ -240,11 +240,11 @@ public final class TramoSeatsProtos {
         internal_static_tramoseats_TramoSpec_descriptor,
         new java.lang.String[] { "Basic", "Transform", "Outlier", "Arima", "Automodel", "Regression", "Estimate", });
     internal_static_tramoseats_TramoSpec_BasicSpec_descriptor =
-      internal_static_tramoseats_TramoSpec_descriptor.getNestedTypes().getFirst();
+      internal_static_tramoseats_TramoSpec_descriptor.getNestedTypes().get(0);
     internal_static_tramoseats_TramoSpec_BasicSpec_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_tramoseats_TramoSpec_BasicSpec_descriptor,
-        new java.lang.String[] { "Span", "PreliminaryCheck", });
+        new java.lang.String[] { "Span", "PreliminaryCheck", "AnnualFrequency", });
     internal_static_tramoseats_TramoSpec_TransformSpec_descriptor =
       internal_static_tramoseats_TramoSpec_descriptor.getNestedTypes().get(1);
     internal_static_tramoseats_TramoSpec_TransformSpec_fieldAccessorTable = new
@@ -306,7 +306,7 @@ public final class TramoSeatsProtos {
         internal_static_tramoseats_TramoOutput_descriptor,
         new java.lang.String[] { "Result", "EstimationSpec", "ResultSpec", "Log", "Details", });
     internal_static_tramoseats_TramoOutput_DetailsEntry_descriptor =
-      internal_static_tramoseats_TramoOutput_descriptor.getNestedTypes().getFirst();
+      internal_static_tramoseats_TramoOutput_descriptor.getNestedTypes().get(0);
     internal_static_tramoseats_TramoOutput_DetailsEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_tramoseats_TramoOutput_DetailsEntry_descriptor,
@@ -318,7 +318,7 @@ public final class TramoSeatsProtos {
         internal_static_tramoseats_TramoSeatsOutput_descriptor,
         new java.lang.String[] { "Result", "EstimationSpec", "ResultSpec", "Log", "Details", });
     internal_static_tramoseats_TramoSeatsOutput_DetailsEntry_descriptor =
-      internal_static_tramoseats_TramoSeatsOutput_descriptor.getNestedTypes().getFirst();
+      internal_static_tramoseats_TramoSeatsOutput_descriptor.getNestedTypes().get(0);
     internal_static_tramoseats_TramoSeatsOutput_DetailsEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_tramoseats_TramoSeatsOutput_DetailsEntry_descriptor,

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/TramoSeatsResults.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/TramoSeatsResults.java
@@ -5,8 +5,6 @@
 
 package jdplus.tramoseats.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code tramoseats.TramoSeatsResults}
  */
@@ -14,8 +12,7 @@ public final class TramoSeatsResults extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:tramoseats.TramoSeatsResults)
     TramoSeatsResultsOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -486,8 +483,8 @@ public final class TramoSeatsResults extends
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.tramoseats.base.protobuf.TramoSeatsResults results) {
-        return mergeFrom(results);
+      if (other instanceof jdplus.tramoseats.base.protobuf.TramoSeatsResults) {
+        return mergeFrom((jdplus.tramoseats.base.protobuf.TramoSeatsResults)other);
       } else {
         super.mergeFrom(other);
         return this;

--- a/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/TramoSpec.java
+++ b/jdplus-main-base/jdplus-tramoseats-base-parent/jdplus-tramoseats-base-protobuf/src/main/java/jdplus/tramoseats/base/protobuf/TramoSpec.java
@@ -5,8 +5,6 @@
 
 package jdplus.tramoseats.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code tramoseats.TramoSpec}
  */
@@ -14,8 +12,7 @@ public final class TramoSpec extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:tramoseats.TramoSpec)
     TramoSpecOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -69,6 +66,12 @@ public final class TramoSpec extends
      * @return The preliminaryCheck.
      */
     boolean getPreliminaryCheck();
+
+    /**
+     * <code>int32 annual_frequency = 4;</code>
+     * @return The annualFrequency.
+     */
+    int getAnnualFrequency();
   }
   /**
    * Protobuf type {@code tramoseats.TramoSpec.BasicSpec}
@@ -77,8 +80,7 @@ public final class TramoSpec extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:tramoseats.TramoSpec.BasicSpec)
       BasicSpecOrBuilder {
-      @Serial
-      private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     static {
       com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
         com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -146,6 +148,17 @@ public final class TramoSpec extends
       return preliminaryCheck_;
     }
 
+    public static final int ANNUAL_FREQUENCY_FIELD_NUMBER = 4;
+    private int annualFrequency_ = 0;
+    /**
+     * <code>int32 annual_frequency = 4;</code>
+     * @return The annualFrequency.
+     */
+    @java.lang.Override
+    public int getAnnualFrequency() {
+      return annualFrequency_;
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -166,6 +179,9 @@ public final class TramoSpec extends
       if (preliminaryCheck_ != false) {
         output.writeBool(3, preliminaryCheck_);
       }
+      if (annualFrequency_ != 0) {
+        output.writeInt32(4, annualFrequency_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -182,6 +198,10 @@ public final class TramoSpec extends
       if (preliminaryCheck_ != false) {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(3, preliminaryCheck_);
+      }
+      if (annualFrequency_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(4, annualFrequency_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
@@ -205,6 +225,8 @@ public final class TramoSpec extends
       }
       if (getPreliminaryCheck()
           != other.getPreliminaryCheck()) return false;
+      if (getAnnualFrequency()
+          != other.getAnnualFrequency()) return false;
       if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
@@ -223,6 +245,8 @@ public final class TramoSpec extends
       hash = (37 * hash) + PRELIMINARY_CHECK_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
           getPreliminaryCheck());
+      hash = (37 * hash) + ANNUAL_FREQUENCY_FIELD_NUMBER;
+      hash = (53 * hash) + getAnnualFrequency();
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -366,6 +390,7 @@ public final class TramoSpec extends
           spanBuilder_ = null;
         }
         preliminaryCheck_ = false;
+        annualFrequency_ = 0;
         return this;
       }
 
@@ -409,13 +434,16 @@ public final class TramoSpec extends
         if (((from_bitField0_ & 0x00000002) != 0)) {
           result.preliminaryCheck_ = preliminaryCheck_;
         }
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.annualFrequency_ = annualFrequency_;
+        }
         result.bitField0_ |= to_bitField0_;
       }
 
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec.BasicSpec spec) {
-          return mergeFrom(spec);
+        if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec.BasicSpec) {
+          return mergeFrom((jdplus.tramoseats.base.protobuf.TramoSpec.BasicSpec)other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -429,6 +457,9 @@ public final class TramoSpec extends
         }
         if (other.getPreliminaryCheck() != false) {
           setPreliminaryCheck(other.getPreliminaryCheck());
+        }
+        if (other.getAnnualFrequency() != 0) {
+          setAnnualFrequency(other.getAnnualFrequency());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
@@ -468,6 +499,11 @@ public final class TramoSpec extends
                 bitField0_ |= 0x00000002;
                 break;
               } // case 24
+              case 32: {
+                annualFrequency_ = input.readInt32();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 32
               default: {
                 if (!super.parseUnknownField(input, extensionRegistry, tag)) {
                   done = true; // was an endgroup tag
@@ -638,6 +674,38 @@ public final class TramoSpec extends
         return this;
       }
 
+      private int annualFrequency_ ;
+      /**
+       * <code>int32 annual_frequency = 4;</code>
+       * @return The annualFrequency.
+       */
+      @java.lang.Override
+      public int getAnnualFrequency() {
+        return annualFrequency_;
+      }
+      /**
+       * <code>int32 annual_frequency = 4;</code>
+       * @param value The annualFrequency to set.
+       * @return This builder for chaining.
+       */
+      public Builder setAnnualFrequency(int value) {
+
+        annualFrequency_ = value;
+        bitField0_ |= 0x00000004;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>int32 annual_frequency = 4;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearAnnualFrequency() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        annualFrequency_ = 0;
+        onChanged();
+        return this;
+      }
+
       // @@protoc_insertion_point(builder_scope:tramoseats.TramoSpec.BasicSpec)
     }
 
@@ -734,8 +802,7 @@ public final class TramoSpec extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:tramoseats.TramoSpec.TransformSpec)
       TransformSpecOrBuilder {
-      @Serial
-      private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     static {
       com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
         com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -1103,8 +1170,8 @@ public final class TramoSpec extends
 
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec.TransformSpec spec) {
-          return mergeFrom(spec);
+        if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec.TransformSpec) {
+          return mergeFrom((jdplus.tramoseats.base.protobuf.TramoSpec.TransformSpec)other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -1483,8 +1550,7 @@ public final class TramoSpec extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:tramoseats.TramoSpec.OutlierSpec)
       OutlierSpecOrBuilder {
-      @Serial
-      private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     static {
       com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
         com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -2011,8 +2077,8 @@ public final class TramoSpec extends
 
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec.OutlierSpec spec) {
-          return mergeFrom(spec);
+        if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec.OutlierSpec) {
+          return mergeFrom((jdplus.tramoseats.base.protobuf.TramoSpec.OutlierSpec)other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -2631,8 +2697,7 @@ public final class TramoSpec extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:tramoseats.TramoSpec.AutoModelSpec)
       AutoModelSpecOrBuilder {
-      @Serial
-      private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     static {
       com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
         com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -3128,8 +3193,8 @@ public final class TramoSpec extends
 
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec.AutoModelSpec spec) {
-          return mergeFrom(spec);
+        if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec.AutoModelSpec) {
+          return mergeFrom((jdplus.tramoseats.base.protobuf.TramoSpec.AutoModelSpec)other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -3647,8 +3712,7 @@ public final class TramoSpec extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:tramoseats.TramoSpec.EasterSpec)
       EasterSpecOrBuilder {
-      @Serial
-      private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     static {
       com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
         com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -4070,8 +4134,8 @@ public final class TramoSpec extends
 
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec.EasterSpec spec) {
-          return mergeFrom(spec);
+        if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec.EasterSpec) {
+          return mergeFrom((jdplus.tramoseats.base.protobuf.TramoSpec.EasterSpec)other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -4635,8 +4699,7 @@ public final class TramoSpec extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:tramoseats.TramoSpec.TradingDaysSpec)
       TradingDaysSpecOrBuilder {
-      @Serial
-      private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     static {
       com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
         com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -4721,8 +4784,8 @@ public final class TramoSpec extends
     @java.lang.Override
     public java.lang.String getHolidays() {
       java.lang.Object ref = holidays_;
-      if (ref instanceof java.lang.String string) {
-        return string;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
@@ -4739,10 +4802,10 @@ public final class TramoSpec extends
     public com.google.protobuf.ByteString
         getHolidaysBytes() {
       java.lang.Object ref = holidays_;
-      if (ref instanceof java.lang.String string) {
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                string);
+                (java.lang.String) ref);
         holidays_ = b;
         return b;
       } else {
@@ -5350,8 +5413,8 @@ public final class TramoSpec extends
 
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec.TradingDaysSpec spec) {
-          return mergeFrom(spec);
+        if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec.TradingDaysSpec) {
+          return mergeFrom((jdplus.tramoseats.base.protobuf.TramoSpec.TradingDaysSpec)other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -5664,10 +5727,10 @@ public final class TramoSpec extends
       public com.google.protobuf.ByteString
           getHolidaysBytes() {
         java.lang.Object ref = holidays_;
-        if (ref instanceof java.lang.String string) {
+        if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  string);
+                  (java.lang.String) ref);
           holidays_ = b;
           return b;
         } else {
@@ -5803,7 +5866,7 @@ public final class TramoSpec extends
       public Builder clearUsers() {
         users_ =
           com.google.protobuf.LazyStringArrayList.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000008);
+        bitField0_ = (bitField0_ & ~0x00000008);;
         onChanged();
         return this;
       }
@@ -6595,8 +6658,7 @@ public final class TramoSpec extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:tramoseats.TramoSpec.RegressionSpec)
       RegressionSpecOrBuilder {
-      @Serial
-      private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     static {
       com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
         com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -7332,8 +7394,8 @@ public final class TramoSpec extends
 
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec.RegressionSpec spec) {
-          return mergeFrom(spec);
+        if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec.RegressionSpec) {
+          return mergeFrom((jdplus.tramoseats.base.protobuf.TramoSpec.RegressionSpec)other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -9029,8 +9091,7 @@ public final class TramoSpec extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:tramoseats.TramoSpec.EstimateSpec)
       EstimateSpecOrBuilder {
-      @Serial
-      private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     static {
       com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
         com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -9422,8 +9483,8 @@ public final class TramoSpec extends
 
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec.EstimateSpec spec) {
-          return mergeFrom(spec);
+        if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec.EstimateSpec) {
+          return mergeFrom((jdplus.tramoseats.base.protobuf.TramoSpec.EstimateSpec)other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -10380,8 +10441,8 @@ public final class TramoSpec extends
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec spec) {
-        return mergeFrom(spec);
+      if (other instanceof jdplus.tramoseats.base.protobuf.TramoSpec) {
+        return mergeFrom((jdplus.tramoseats.base.protobuf.TramoSpec)other);
       } else {
         super.mergeFrom(other);
         return this;

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-api/src/main/java/jdplus/x13/base/api/regarima/BasicSpec.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-api/src/main/java/jdplus/x13/base/api/regarima/BasicSpec.java
@@ -37,6 +37,7 @@ public final class BasicSpec implements Validatable<BasicSpec> {
 
     @lombok.NonNull
     private TimeSelector span;
+    private int frequency;
     private boolean preprocessing;
     private boolean preliminaryCheck;
 
@@ -44,6 +45,7 @@ public final class BasicSpec implements Validatable<BasicSpec> {
     public static Builder builder() {
         return new Builder()
                 .span(TimeSelector.all())
+                .frequency(0)
                 .preprocessing(DEF_PREPROCESSING)
                 .preliminaryCheck(DEF_PRELIMINARYCHECK);
     }

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-api/src/main/java/jdplus/x13/base/api/regarima/BasicSpec.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-api/src/main/java/jdplus/x13/base/api/regarima/BasicSpec.java
@@ -37,6 +37,7 @@ public final class BasicSpec implements Validatable<BasicSpec> {
 
     @lombok.NonNull
     private TimeSelector span;
+    @lombok.EqualsAndHashCode.Exclude
     private int frequency;
     private boolean preprocessing;
     private boolean preliminaryCheck;

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-api/src/main/java/jdplus/x13/base/api/regarima/RegArimaSpec.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-api/src/main/java/jdplus/x13/base/api/regarima/RegArimaSpec.java
@@ -108,6 +108,33 @@ public final class RegArimaSpec implements Validatable<RegArimaSpec>, ProcSpecif
             return this;
         }
     }
+    
+    public int getFrequency(){
+        return basic.getFrequency();
+    }
+    
+    public RegArimaSpec setFrequency(int freq){
+        int frequency=basic.getFrequency();
+        if (freq == frequency) {
+            // Nothing to do
+            return this;
+        }
+        Builder builder = toBuilder()
+                .basic(basic.toBuilder().frequency(freq).buildWithoutValidation());
+        if (frequency == 0) {
+            // Nothing to check
+            return builder.buildWithoutValidation();
+        }
+        // Remove pre-specified variables (keeping them would mean a lot of checks/conversions/hypotheses...)
+        // We should perhaps change the calendar effects
+        builder.regression(regression.toBuilder()
+                .clearOutliers()
+                .clearInterventionVariables()
+                .clearRamps()
+                .clearUserDefinedVariables()
+                .build());
+        return builder.buildWithoutValidation();
+    }
 
     //<editor-fold defaultstate="collapsed" desc="Default specifications">
     public static final RegArimaSpec RGDISABLED, RG0, RG1, RG2, RG3, RG4, RG5;

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-api/src/main/java/jdplus/x13/base/api/regarima/X13Frequency.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-api/src/main/java/jdplus/x13/base/api/regarima/X13Frequency.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2013 National Bank of Belgium
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * http://ec.europa.eu/idabc/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
+package jdplus.x13.base.api.regarima;
+
+import jdplus.toolkit.base.api.timeseries.HasAnnualFrequency;
+import jdplus.toolkit.base.api.timeseries.TsException;
+import jdplus.toolkit.base.api.timeseries.TsUnit;
+import lombok.NonNull;
+import nbbrd.design.Development;
+import nbbrd.design.RepresentableAs;
+import nbbrd.design.RepresentableAsInt;
+import nbbrd.design.StaticFactoryMethod;
+
+/**
+ * Frequency of an event.
+ * Only regular frequencies higher or equal to yearly frequency are considered.
+ *
+ * @author Jean Palate
+ */
+@RepresentableAsInt
+@RepresentableAs(value = TsUnit.class, parseMethodName = "parseTsUnit")
+@Development(status = Development.Status.Release)
+public enum X13Frequency {
+    /**
+     * Undefined frequency. To be used when the frequency of an event is
+     * unknown.
+     */
+    Undefined(0),
+    /**
+     * One event by year
+     */
+    Yearly(1),
+    /*
+     * One event every half-year
+     */
+    /**
+     *
+     */
+    HalfYearly(2),
+    /*
+     * One event every quarter
+     */
+    /**
+     *
+     */
+    Quarterly(4),
+    /*
+     * One event every month
+     */
+    /**
+     *
+     */
+    Monthly(12);
+
+    private static final X13Frequency[] ENUMS = X13Frequency.values();
+
+    /**
+     * Enum correspondence to an integer
+     *
+     * @param value Integer representation of the frequency
+     * @return Enum representation of the frequency
+     */
+    @StaticFactoryMethod
+    public static @NonNull X13Frequency parse(int value) throws IllegalArgumentException {
+        if (value <= 0)
+            return Undefined;
+        if (12 % value == 0) {
+            for (X13Frequency anEnum : ENUMS) {
+                if (value == anEnum.value) {
+                    return anEnum;
+                }
+            }
+        }
+        throw new IllegalArgumentException("Cannot parse " + value);
+    }
+
+    @StaticFactoryMethod
+    public static @NonNull X13Frequency parse(@NonNull HasAnnualFrequency object) throws IllegalArgumentException {
+        return parse(object.getAnnualFrequency());
+    }
+
+    private final int value;
+
+    X13Frequency(final int value) {
+        this.value = value;
+    }
+
+    /**
+     * Integer representation of the frequency
+     *
+     * @return The number of events by year
+     */
+    public int toInt() {
+        return value;
+    }
+
+    /**
+     * Checks that any period of the given frequency is strictly contained in
+     * a period of this frequency
+     *
+     * @param other The other frequency to be checked
+     * @return True if other is a multiple of this frequency,
+     * false otherwise
+     */
+    public boolean contains(X13Frequency other) {
+        return other.value > value && other.value % value == 0;
+    }
+
+    public int ratio(X13Frequency other) {
+        if (value % other.value != 0) {
+            throw new TsException(TsException.INCOMPATIBLE_FREQ);
+        }
+        return value / other.value;
+    }
+
+    public @NonNull TsUnit toTsUnit() {
+        return switch (this) {
+            case Yearly -> TsUnit.P1Y;
+            case HalfYearly -> TsUnit.P6M;
+            case Quarterly -> TsUnit.P3M;
+            case Monthly -> TsUnit.P1M;
+            case Undefined -> TsUnit.UNDEFINED;
+        };
+    }
+
+    @StaticFactoryMethod
+    public static @NonNull X13Frequency parseTsUnit(@NonNull TsUnit unit) throws IllegalArgumentException {
+        return parse(unit.getAnnualFrequency());
+    }
+}

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-api/src/main/java/jdplus/x13/base/api/x11/X11Exception.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-api/src/main/java/jdplus/x13/base/api/x11/X11Exception.java
@@ -32,7 +32,8 @@ public class X11Exception extends SaException {
      *
      */
     public static final String ERR_NEG = "Multiplicative decomposition of non positive series",
-            ERR_FREQ = "Invalid frequency", ERR_LENGTH = "Not enough observations", ERR_MISSING = "Missing values are not allowed";
+            ERR_FREQ = "Invalid frequency", ERR_LENGTH = "Not enough observations", ERR_MISSING = "Missing values are not allowed",
+            ERR_FILTERS = "Filters incompatible with the periodicity", ERR_SIGMAVEC = "Sigma vector incompatible with the periodicity";
 
     /**
      *

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-api/src/main/java/jdplus/x13/base/api/x11/X11Spec.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-api/src/main/java/jdplus/x13/base/api/x11/X11Spec.java
@@ -147,6 +147,23 @@ public final class X11Spec implements Validatable<X11Spec> {
         return this;
     }
 
+    public X11Spec checkAnnualFrequency(int period) {
+        if ((sigmaVec == null || sigmaVec.length == period) && (filters == null || filters.length == period)) {
+            return this;
+        }
+        Builder builder = toBuilder();
+
+        if (sigmaVec != null) {
+            builder.calendarSigma(CalendarSigmaOption.None)
+                    .sigmaVec(null);
+        }
+        if (filters != null) {
+            builder.filters(MSR);
+        }
+
+        return builder.build();
+    }
+
     public static class Builder implements Validatable.Builder<X11Spec> {
     }
 

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-api/src/main/java/jdplus/x13/base/api/x13/X13Spec.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-api/src/main/java/jdplus/x13/base/api/x13/X13Spec.java
@@ -76,6 +76,22 @@ public class X13Spec implements Validatable<X13Spec>, SaSpecification {
 
     public static class Builder implements Validatable.Builder<X13Spec> {
     }
+    
+    @Override
+    public int getFrequency(){
+        return regArima.getBasic().getFrequency();
+    }
+    
+    @Override
+    public X13Spec setFrequency(int freq){
+        if (getFrequency() == freq)
+            return this;
+        
+        return toBuilder()
+                .regArima(regArima.setFrequency(freq))
+                .x11(x11.checkAnnualFrequency(freq))
+                .buildWithoutValidation();
+    }
 
     //<editor-fold defaultstate="collapsed" desc="Default specifications">
     public static final X13Spec RSAX11, RSA0, RSA1, RSA2, RSA3, RSA4, RSA5;

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-core/src/main/java/jdplus/x13/base/core/x11/X11Kernel.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-core/src/main/java/jdplus/x13/base/core/x11/X11Kernel.java
@@ -18,10 +18,12 @@ import jdplus.x13.base.core.x11.pseudoadd.X11CStepPseudoAdd;
 import jdplus.x13.base.core.x11.pseudoadd.X11DStepPseudoAdd;
 import java.util.Arrays;
 import jdplus.toolkit.base.api.data.DoublesMath;
+import jdplus.toolkit.base.api.processing.ProcessingLog;
 import jdplus.toolkit.base.core.data.DataBlock;
 import jdplus.toolkit.base.core.math.linearfilters.FiniteFilter;
 import jdplus.toolkit.base.core.math.linearfilters.SymmetricFilter;
 import jdplus.x13.base.api.x11.BiasCorrection;
+import jdplus.x13.base.api.x11.CalendarSigmaOption;
 import jdplus.x13.base.core.x11.filter.X11TrendCycleFilterFactory;
 import jdplus.x13.base.core.x11.filter.endpoints.CopyEndPoints;
 
@@ -44,15 +46,22 @@ public class X11Kernel {
         return x;
     }
 
+    public X11Results process(@lombok.NonNull TsData timeSeries, @lombok.NonNull X11Spec spec) {
+        return process(timeSeries, spec, ProcessingLog.dummy());
+    }
+
     /**
      *
      * @param timeSeries Time series including forecasts/backcasts
      * @param spec
+     * @param log
      * @return
      */
-    public X11Results process(@lombok.NonNull TsData timeSeries, @lombok.NonNull X11Spec spec) {
+    public X11Results process(@lombok.NonNull TsData timeSeries, @lombok.NonNull X11Spec spec, ProcessingLog log) {
         clear();
-        check(timeSeries, spec);
+        if (!check(timeSeries, spec, log)) {
+            return null;
+        }
 
         input = timeSeries;
         DoubleSeq data = input.getValues();
@@ -79,20 +88,41 @@ public class X11Kernel {
         return buildResults(timeSeries.getStart(), spec);
     }
 
-    private void check(TsData timeSeries, X11Spec spec) throws X11Exception, IllegalArgumentException {
+    private final String X11 = "x11";
+
+    private boolean check(TsData timeSeries, X11Spec spec, ProcessingLog log) {
+        log.push(X11);
         int frequency = timeSeries.getAnnualFrequency();
-        if (frequency == -1) {
-            throw new IllegalArgumentException("Frequency of the time series must be compatible with years");
-        }
-        if (timeSeries.getValues().length() < 3 * frequency) {
-            throw new X11Exception(X11Exception.ERR_LENGTH);
-        }
-        if (!timeSeries.getValues().allMatch(Double::isFinite)) {
-            throw new X11Exception(X11Exception.ERR_MISSING);
-        }
-        if ((spec.getMode() == DecompositionMode.Multiplicative || spec.getMode() == DecompositionMode.LogAdditive)
-                && timeSeries.getValues().anyMatch(x -> x <= 0)) {
-            throw new X11Exception(X11Exception.ERR_NEG);
+        try {
+            boolean ok = true;
+            if (frequency == -1) {
+                log.error("Frequency of the time series must be compatible with years");
+                ok = false;
+            }
+            if (timeSeries.getValues().length() < 3 * frequency) {
+                log.error(X11Exception.ERR_LENGTH);
+                ok = false;
+            }
+            if (!timeSeries.getValues().allMatch(Double::isFinite)) {
+                log.error(X11Exception.ERR_MISSING);
+                ok = false;
+            }
+            if ((spec.getMode() == DecompositionMode.Multiplicative || spec.getMode() == DecompositionMode.LogAdditive)
+                    && timeSeries.getValues().anyMatch(x -> x <= 0)) {
+                log.error(X11Exception.ERR_NEG);
+                ok = false;
+            }
+            if ((spec.getFilters().length > 1 && spec.getFilters().length != frequency)) {
+                log.error(X11Exception.ERR_FILTERS);
+                ok = false;
+            }
+            if (spec.getCalendarSigma() == CalendarSigmaOption.Select && spec.getSigmaVec().length != frequency) {
+                log.error(X11Exception.ERR_SIGMAVEC);
+                ok = false;
+            }
+            return ok;
+        } finally {
+            log.pop();
         }
     }
 

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-core/src/main/java/jdplus/x13/base/core/x13/X13Kernel.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-core/src/main/java/jdplus/x13/base/core/x13/X13Kernel.java
@@ -75,7 +75,7 @@ public class X13Kernel {
 //                spec.getRegArima().getOutliers().isUsed() || spec.getRegArima().getRegression().isUsed());
         RegArimaKernel regarima = RegArimaKernel.of(spec.getRegArima(), context);
         SaVariablesMapping mapping = new SaVariablesMapping();
-        // TO DO: fill maping with existing information in TramoSpec (section Regression)
+        // TO DO: fill maping with existing information in RegArimaSpec (section Regression)
         return new X13Kernel(check, regarima, mapping, spec.getX11(), blPreprop, CholetteProcessor.of(spec.getBenchmarking()));
     }
 
@@ -121,11 +121,16 @@ public class X13Kernel {
             // Step 3. X11
             X11Kernel x11 = new X11Kernel();
             X11Spec nspec = updateSpec(spec, preprocessing);
-            X11Results xr = x11.process(alin, nspec);
-            X13Finals finals = finals(nspec.getMode(), preadjustment, xr);
+            X11Results xr = x11.process(alin, nspec, log);
+            X13Finals finals = null;
             SaBenchmarkingResults bench = null;
-            if (cholette != null) {
-                bench = cholette.process(s, TsData.concatenate(finals.getD11final(), finals.getD11a()), preprocessing);
+            X13Diagnostics diags = null;
+            if (xr != null) {
+                finals = finals(nspec.getMode(), preadjustment, xr);
+                if (cholette != null) {
+                    bench = cholette.process(s, TsData.concatenate(finals.getD11final(), finals.getD11a()), preprocessing);
+                }
+                diags = X13Diagnostics.of(preprocessing, preadjustment, xr, finals);
             }
             return X13Results.builder()
                     .preprocessing(preprocessing)
@@ -133,7 +138,7 @@ public class X13Kernel {
                     .decomposition(xr)
                     .finals(finals)
                     .benchmarking(bench)
-                    .diagnostics(X13Diagnostics.of(preprocessing, preadjustment, xr, finals))
+                    .diagnostics(diags)
                     .log(log)
                     .build();
         } catch (Exception err) {

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-core/src/main/java/jdplus/x13/base/core/x13/regarima/RegArimaFactory.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-core/src/main/java/jdplus/x13/base/core/x13/regarima/RegArimaFactory.java
@@ -45,6 +45,7 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import jdplus.toolkit.base.api.timeseries.regression.JulianEasterVariable;
+import jdplus.x13.base.api.regarima.BasicSpec;
 
 /**
  *
@@ -58,7 +59,8 @@ public class RegArimaFactory /*implements SaProcessingFactory<RegArimaSeatsSpec,
     public static RegArimaFactory getInstance(){return INSTANCE;}
 
     public RegArimaSpec generateSpec(RegArimaSpec spec, GeneralLinearModel.Description<SarimaSpec> desc) {
-        RegArimaSpec.Builder builder = spec.toBuilder();
+        BasicSpec basic = spec.getBasic().toBuilder().frequency(desc.getDomain().getAnnualFrequency()).build();
+        RegArimaSpec.Builder builder = spec.toBuilder().basic(basic);
         update(spec.getTransform(), desc, builder);
         update(spec.getArima(), desc, builder);
         update(spec.getAutoModel(), desc, builder);

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-core/src/test/java/jdplus/x13/base/core/x11/X11KernelTest.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-core/src/test/java/jdplus/x13/base/core/x11/X11KernelTest.java
@@ -21,6 +21,7 @@ import jdplus.x13.base.api.x11.BiasCorrection;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -132,8 +133,7 @@ public class X11KernelTest {
         X11Kernel instanceKernel = new X11Kernel();
         X11Spec spec = X11Spec.builder().build();
         jdplus.toolkit.base.api.timeseries.TsData tsData = jdplus.toolkit.base.api.timeseries.TsData.ofInternal(TsPeriod.daily(1990, 1, 1), WU5636);
-        assertThrows(IllegalArgumentException.class, () ->
-            instanceKernel.process(tsData, spec));
+        assertNull(instanceKernel.process(tsData, spec));
     }
 
     @org.junit.jupiter.api.Test
@@ -142,8 +142,7 @@ public class X11KernelTest {
         X11Spec spec = X11Spec.builder().build();
         double[] copy = Arrays.copyOf(WU5636, 35);
         jdplus.toolkit.base.api.timeseries.TsData tsData = jdplus.toolkit.base.api.timeseries.TsData.ofInternal(TsPeriod.monthly(1990, 1), copy);
-        assertThrows(X11Exception.class, () ->
-            instanceKernel.process(tsData, spec));
+        assertNull(instanceKernel.process(tsData, spec));
     }
 
     @org.junit.jupiter.api.Test
@@ -153,8 +152,7 @@ public class X11KernelTest {
         double[] copy = Arrays.copyOf(WU5636, 36);
         copy[0] = Double.NaN;
         jdplus.toolkit.base.api.timeseries.TsData tsData = jdplus.toolkit.base.api.timeseries.TsData.ofInternal(TsPeriod.monthly(1990, 1), copy);
-        assertThrows(X11Exception.class, () ->
-            instanceKernel.process(tsData, spec));
+        assertNull(instanceKernel.process(tsData, spec));
     }
 
     @org.junit.jupiter.api.Test
@@ -164,8 +162,7 @@ public class X11KernelTest {
         double[] copy = Arrays.copyOf(WU5636, 36);
         copy[0] = -1;
         jdplus.toolkit.base.api.timeseries.TsData tsData = jdplus.toolkit.base.api.timeseries.TsData.ofInternal(TsPeriod.monthly(1990, 1), copy);
-        assertThrows(X11Exception.class, () ->
-            instanceKernel.process(tsData, spec));
+        assertNull(instanceKernel.process(tsData, spec));
     }
 
     @org.junit.jupiter.api.Test
@@ -175,8 +172,7 @@ public class X11KernelTest {
         double[] copy = Arrays.copyOf(WU5636, 36);
         copy[0] = -1;
         jdplus.toolkit.base.api.timeseries.TsData tsData = jdplus.toolkit.base.api.timeseries.TsData.ofInternal(TsPeriod.monthly(1990, 1), copy);
-        assertThrows(X11Exception.class, () ->
-            instanceKernel.process(tsData, spec));
+        assertNull(instanceKernel.process(tsData, spec));
     }
 
     @Test

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-information/src/main/java/jdplus/x13/base/information/BasicSpecMapping.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-information/src/main/java/jdplus/x13/base/information/BasicSpecMapping.java
@@ -28,7 +28,7 @@ import java.util.Map;
 @lombok.experimental.UtilityClass
 class BasicSpecMapping {
 
-    final String SPAN = "span", PREPROCESS = "preprocess", PRELIMINARYCHECK = "preliminarycheck";
+    final String SPAN = "span", PREPROCESS = "preprocess", PRELIMINARYCHECK = "preliminarycheck", FREQUENCY = "frequency";
 
     void fillDictionary(String prefix, Map<String, Class> dic) {
         dic.put(InformationSet.item(prefix, SPAN), TimeSelector.class);
@@ -41,6 +41,9 @@ class BasicSpecMapping {
             return null;
         }
         InformationSet info = new InformationSet();
+        if (verbose || spec.getFrequency() != 0) {
+            info.add(FREQUENCY, spec.getFrequency());
+        }
         if (verbose || spec.getSpan().getType() != TimeSelector.SelectionType.All) {
             info.add(SPAN, spec.getSpan());
         }
@@ -60,6 +63,10 @@ class BasicSpecMapping {
         }
 
         BasicSpec.Builder builder = BasicSpec.builder();
+        Integer freq = info.get(FREQUENCY, Integer.class);
+        if (freq != null) {
+            builder.frequency(freq);
+        }
         TimeSelector span = info.get(SPAN, TimeSelector.class);
         if (span != null) {
             builder.span(span);

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-information/src/main/java/jdplus/x13/base/information/BasicSpecMapping.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-information/src/main/java/jdplus/x13/base/information/BasicSpecMapping.java
@@ -41,7 +41,7 @@ class BasicSpecMapping {
             return null;
         }
         InformationSet info = new InformationSet();
-        if (verbose || spec.getFrequency() != 0) {
+        if (spec.getFrequency() != 0) {
             info.add(FREQUENCY, spec.getFrequency());
         }
         if (verbose || spec.getSpan().getType() != TimeSelector.SelectionType.All) {
@@ -66,7 +66,8 @@ class BasicSpecMapping {
         Integer freq = info.get(FREQUENCY, Integer.class);
         if (freq != null) {
             builder.frequency(freq);
-        }
+        }else
+            builder.frequency(-1);
         TimeSelector span = info.get(SPAN, TimeSelector.class);
         if (span != null) {
             builder.span(span);

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/AutomaticTradingDays.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/AutomaticTradingDays.java
@@ -79,13 +79,13 @@ public enum AutomaticTradingDays
    * @return The enum associated with the given numeric wire value.
    */
   public static AutomaticTradingDays forNumber(int value) {
-    return switch (value) {
-      case 0 -> TD_AUTO_NO;
-      case 1 -> TD_AUTO_WALD;
-      case 2 -> TD_AUTO_AIC;
-      case 3 -> TD_AUTO_BIC;
-      default -> null;
-    };
+    switch (value) {
+      case 0: return TD_AUTO_NO;
+      case 1: return TD_AUTO_WALD;
+      case 2: return TD_AUTO_AIC;
+      case 3: return TD_AUTO_BIC;
+      default: return null;
+    }
   }
 
   public static com.google.protobuf.Internal.EnumLiteMap<AutomaticTradingDays>

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/BasicProto.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/BasicProto.java
@@ -29,7 +29,8 @@ public class BasicProto {
     public void fill(BasicSpec spec, RegArimaSpec.BasicSpec.Builder builder) {
         builder.setSpan(ToolkitProtosUtility.convert(spec.getSpan()))
                 .setPreliminaryCheck(spec.isPreliminaryCheck())
-                .setPreprocessing(spec.isPreprocessing());
+                .setPreprocessing(spec.isPreprocessing())
+                .setAnnualFrequency(spec.getFrequency());
     }
 
     public RegArimaSpec.BasicSpec convert(BasicSpec spec) {
@@ -43,6 +44,7 @@ public class BasicProto {
                 .span(ToolkitProtosUtility.convert(spec.getSpan()))
                 .preprocessing(spec.getPreprocessing())
                 .preliminaryCheck(spec.getPreliminaryCheck())
+                .frequency(spec.getAnnualFrequency())
                 .build();
 
     }

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/BiasCorrection.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/BiasCorrection.java
@@ -79,13 +79,13 @@ public enum BiasCorrection
    * @return The enum associated with the given numeric wire value.
    */
   public static BiasCorrection forNumber(int value) {
-    return switch (value) {
-      case 0 -> BIAS_NONE;
-      case 1 -> BIAS_LEGACY;
-      case 2 -> BIAS_SMOOTH;
-      case 3 -> BIAS_RATIO;
-      default -> null;
-    };
+    switch (value) {
+      case 0: return BIAS_NONE;
+      case 1: return BIAS_LEGACY;
+      case 2: return BIAS_SMOOTH;
+      case 3: return BIAS_RATIO;
+      default: return null;
+    }
   }
 
   public static com.google.protobuf.Internal.EnumLiteMap<BiasCorrection>

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/CalendarSigma.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/CalendarSigma.java
@@ -79,13 +79,13 @@ public enum CalendarSigma
    * @return The enum associated with the given numeric wire value.
    */
   public static CalendarSigma forNumber(int value) {
-    return switch (value) {
-      case 0 -> SIGMA_NONE;
-      case 1 -> SIGMA_SIGNIF;
-      case 2 -> SIGMA_ALL;
-      case 3 -> SIGMA_SELECT;
-      default -> null;
-    };
+    switch (value) {
+      case 0: return SIGMA_NONE;
+      case 1: return SIGMA_SIGNIF;
+      case 2: return SIGMA_ALL;
+      case 3: return SIGMA_SELECT;
+      default: return null;
+    }
   }
 
   public static com.google.protobuf.Internal.EnumLiteMap<CalendarSigma>

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/DecompositionMode.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/DecompositionMode.java
@@ -87,14 +87,14 @@ public enum DecompositionMode
    * @return The enum associated with the given numeric wire value.
    */
   public static DecompositionMode forNumber(int value) {
-    return switch (value) {
-      case 0 -> MODE_UNKNOWN;
-      case 1 -> MODE_ADDITIVE;
-      case 2 -> MODE_MULTIPLICATIVE;
-      case 3 -> MODE_LOGADDITIVE;
-      case 4 -> MODE_PSEUDOADDITIVE;
-      default -> null;
-    };
+    switch (value) {
+      case 0: return MODE_UNKNOWN;
+      case 1: return MODE_ADDITIVE;
+      case 2: return MODE_MULTIPLICATIVE;
+      case 3: return MODE_LOGADDITIVE;
+      case 4: return MODE_PSEUDOADDITIVE;
+      default: return null;
+    }
   }
 
   public static com.google.protobuf.Internal.EnumLiteMap<DecompositionMode>
@@ -123,7 +123,7 @@ public enum DecompositionMode
   }
   public static final com.google.protobuf.Descriptors.EnumDescriptor
       getDescriptor() {
-    return jdplus.x13.base.protobuf.X13Protos.getDescriptor().getEnumTypes().getFirst();
+    return jdplus.x13.base.protobuf.X13Protos.getDescriptor().getEnumTypes().get(0);
   }
 
   private static final DecompositionMode[] VALUES = values();

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/Diagnostics.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/Diagnostics.java
@@ -5,8 +5,6 @@
 
 package jdplus.x13.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code x13.Diagnostics}
  */
@@ -14,8 +12,7 @@ public final class Diagnostics extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:x13.Diagnostics)
     DiagnosticsOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -324,8 +321,8 @@ public final class Diagnostics extends
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.x13.base.protobuf.Diagnostics diagnostics) {
-        return mergeFrom(diagnostics);
+      if (other instanceof jdplus.x13.base.protobuf.Diagnostics) {
+        return mergeFrom((jdplus.x13.base.protobuf.Diagnostics)other);
       } else {
         super.mergeFrom(other);
         return this;

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/EasterType.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/EasterType.java
@@ -79,13 +79,13 @@ public enum EasterType
    * @return The enum associated with the given numeric wire value.
    */
   public static EasterType forNumber(int value) {
-    return switch (value) {
-      case 0 -> EASTER_UNUSED;
-      case 1 -> EASTER_STANDARD;
-      case 2 -> EASTER_JULIAN;
-      case 3 -> EASTER_SC;
-      default -> null;
-    };
+    switch (value) {
+      case 0: return EASTER_UNUSED;
+      case 1: return EASTER_STANDARD;
+      case 2: return EASTER_JULIAN;
+      case 3: return EASTER_SC;
+      default: return null;
+    }
   }
 
   public static com.google.protobuf.Internal.EnumLiteMap<EasterType>

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/MStatistics.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/MStatistics.java
@@ -5,8 +5,6 @@
 
 package jdplus.x13.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code x13.MStatistics}
  */
@@ -14,8 +12,7 @@ public final class MStatistics extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:x13.MStatistics)
     MStatisticsOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -626,8 +623,8 @@ public final class MStatistics extends
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.x13.base.protobuf.MStatistics statistics) {
-        return mergeFrom(statistics);
+      if (other instanceof jdplus.x13.base.protobuf.MStatistics) {
+        return mergeFrom((jdplus.x13.base.protobuf.MStatistics)other);
       } else {
         super.mergeFrom(other);
         return this;

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/OutlierMethod.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/OutlierMethod.java
@@ -63,11 +63,11 @@ public enum OutlierMethod
    * @return The enum associated with the given numeric wire value.
    */
   public static OutlierMethod forNumber(int value) {
-    return switch (value) {
-      case 0 -> OUTLIER_ADDONE;
-      case 1 -> OUTLIER_ADDALL;
-      default -> null;
-    };
+    switch (value) {
+      case 0: return OUTLIER_ADDONE;
+      case 1: return OUTLIER_ADDALL;
+      default: return null;
+    }
   }
 
   public static com.google.protobuf.Internal.EnumLiteMap<OutlierMethod>

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/RegArimaOutput.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/RegArimaOutput.java
@@ -5,8 +5,6 @@
 
 package jdplus.x13.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code x13.RegArimaOutput}
  */
@@ -14,8 +12,7 @@ public final class RegArimaOutput extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:x13.RegArimaOutput)
     RegArimaOutputOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -625,8 +622,8 @@ jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail defaultValue
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.x13.base.protobuf.RegArimaOutput output) {
-        return mergeFrom(output);
+      if (other instanceof jdplus.x13.base.protobuf.RegArimaOutput) {
+        return mergeFrom((jdplus.x13.base.protobuf.RegArimaOutput)other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -1217,7 +1214,7 @@ jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail defaultValue
     private static final class DetailsConverter implements com.google.protobuf.MapFieldBuilder.Converter<java.lang.String, jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetailOrBuilder, jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail> {
       @java.lang.Override
       public jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail build(jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetailOrBuilder val) {
-        if (val instanceof jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail detail) { return detail; }
+        if (val instanceof jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail) { return (jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail) val; }
         return ((jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail.Builder) val).build();
       }
 
@@ -1225,7 +1222,7 @@ jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail defaultValue
       public com.google.protobuf.MapEntry<java.lang.String, jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail> defaultEntry() {
         return DetailsDefaultEntryHolder.defaultEntry;
       }
-    }
+    };
     private static final DetailsConverter detailsConverter = new DetailsConverter();
 
     private com.google.protobuf.MapFieldBuilder<
@@ -1362,8 +1359,8 @@ jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail defaultValue
         entry = jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail.newBuilder();
         builderMap.put(key, entry);
       }
-      if (entry instanceof jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail detail) {
-        entry = detail.toBuilder();
+      if (entry instanceof jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail) {
+        entry = ((jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail) entry).toBuilder();
         builderMap.put(key, entry);
       }
       return (jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail.Builder) entry;

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/RegArimaSpec.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/RegArimaSpec.java
@@ -5,8 +5,6 @@
 
 package jdplus.x13.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code x13.RegArimaSpec}
  */
@@ -14,8 +12,7 @@ public final class RegArimaSpec extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:x13.RegArimaSpec)
     RegArimaSpecOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -75,6 +72,12 @@ public final class RegArimaSpec extends
      * @return The preliminaryCheck.
      */
     boolean getPreliminaryCheck();
+
+    /**
+     * <code>int32 annual_frequency = 4;</code>
+     * @return The annualFrequency.
+     */
+    int getAnnualFrequency();
   }
   /**
    * Protobuf type {@code x13.RegArimaSpec.BasicSpec}
@@ -83,8 +86,7 @@ public final class RegArimaSpec extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:x13.RegArimaSpec.BasicSpec)
       BasicSpecOrBuilder {
-      @Serial
-      private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     static {
       com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
         com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -163,6 +165,17 @@ public final class RegArimaSpec extends
       return preliminaryCheck_;
     }
 
+    public static final int ANNUAL_FREQUENCY_FIELD_NUMBER = 4;
+    private int annualFrequency_ = 0;
+    /**
+     * <code>int32 annual_frequency = 4;</code>
+     * @return The annualFrequency.
+     */
+    @java.lang.Override
+    public int getAnnualFrequency() {
+      return annualFrequency_;
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -186,6 +199,9 @@ public final class RegArimaSpec extends
       if (preliminaryCheck_ != false) {
         output.writeBool(3, preliminaryCheck_);
       }
+      if (annualFrequency_ != 0) {
+        output.writeInt32(4, annualFrequency_);
+      }
       getUnknownFields().writeTo(output);
     }
 
@@ -206,6 +222,10 @@ public final class RegArimaSpec extends
       if (preliminaryCheck_ != false) {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(3, preliminaryCheck_);
+      }
+      if (annualFrequency_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(4, annualFrequency_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
@@ -231,6 +251,8 @@ public final class RegArimaSpec extends
           != other.getPreprocessing()) return false;
       if (getPreliminaryCheck()
           != other.getPreliminaryCheck()) return false;
+      if (getAnnualFrequency()
+          != other.getAnnualFrequency()) return false;
       if (!getUnknownFields().equals(other.getUnknownFields())) return false;
       return true;
     }
@@ -252,6 +274,8 @@ public final class RegArimaSpec extends
       hash = (37 * hash) + PRELIMINARY_CHECK_FIELD_NUMBER;
       hash = (53 * hash) + com.google.protobuf.Internal.hashBoolean(
           getPreliminaryCheck());
+      hash = (37 * hash) + ANNUAL_FREQUENCY_FIELD_NUMBER;
+      hash = (53 * hash) + getAnnualFrequency();
       hash = (29 * hash) + getUnknownFields().hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -396,6 +420,7 @@ public final class RegArimaSpec extends
         }
         preprocessing_ = false;
         preliminaryCheck_ = false;
+        annualFrequency_ = 0;
         return this;
       }
 
@@ -442,13 +467,16 @@ public final class RegArimaSpec extends
         if (((from_bitField0_ & 0x00000004) != 0)) {
           result.preliminaryCheck_ = preliminaryCheck_;
         }
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          result.annualFrequency_ = annualFrequency_;
+        }
         result.bitField0_ |= to_bitField0_;
       }
 
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.BasicSpec spec) {
-          return mergeFrom(spec);
+        if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.BasicSpec) {
+          return mergeFrom((jdplus.x13.base.protobuf.RegArimaSpec.BasicSpec)other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -465,6 +493,9 @@ public final class RegArimaSpec extends
         }
         if (other.getPreliminaryCheck() != false) {
           setPreliminaryCheck(other.getPreliminaryCheck());
+        }
+        if (other.getAnnualFrequency() != 0) {
+          setAnnualFrequency(other.getAnnualFrequency());
         }
         this.mergeUnknownFields(other.getUnknownFields());
         onChanged();
@@ -509,6 +540,11 @@ public final class RegArimaSpec extends
                 bitField0_ |= 0x00000004;
                 break;
               } // case 24
+              case 32: {
+                annualFrequency_ = input.readInt32();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 32
               default: {
                 if (!super.parseUnknownField(input, extensionRegistry, tag)) {
                   done = true; // was an endgroup tag
@@ -711,6 +747,38 @@ public final class RegArimaSpec extends
         return this;
       }
 
+      private int annualFrequency_ ;
+      /**
+       * <code>int32 annual_frequency = 4;</code>
+       * @return The annualFrequency.
+       */
+      @java.lang.Override
+      public int getAnnualFrequency() {
+        return annualFrequency_;
+      }
+      /**
+       * <code>int32 annual_frequency = 4;</code>
+       * @param value The annualFrequency to set.
+       * @return This builder for chaining.
+       */
+      public Builder setAnnualFrequency(int value) {
+
+        annualFrequency_ = value;
+        bitField0_ |= 0x00000008;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>int32 annual_frequency = 4;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearAnnualFrequency() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        annualFrequency_ = 0;
+        onChanged();
+        return this;
+      }
+
       // @@protoc_insertion_point(builder_scope:x13.RegArimaSpec.BasicSpec)
     }
 
@@ -807,8 +875,7 @@ public final class RegArimaSpec extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:x13.RegArimaSpec.TransformSpec)
       TransformSpecOrBuilder {
-      @Serial
-      private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     static {
       com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
         com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -1176,8 +1243,8 @@ public final class RegArimaSpec extends
 
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.TransformSpec spec) {
-          return mergeFrom(spec);
+        if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.TransformSpec) {
+          return mergeFrom((jdplus.x13.base.protobuf.RegArimaSpec.TransformSpec)other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -1567,8 +1634,7 @@ public final class RegArimaSpec extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:x13.RegArimaSpec.OutlierSpec)
       OutlierSpecOrBuilder {
-      @Serial
-      private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     static {
       com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
         com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -1629,8 +1695,7 @@ public final class RegArimaSpec extends
         com.google.protobuf.GeneratedMessage implements
         // @@protoc_insertion_point(message_implements:x13.RegArimaSpec.OutlierSpec.Type)
         TypeOrBuilder {
-        @Serial
-        private static final long serialVersionUID = 0L;
+    private static final long serialVersionUID = 0L;
       static {
         com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
           com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -1671,8 +1736,8 @@ public final class RegArimaSpec extends
       @java.lang.Override
       public java.lang.String getCode() {
         java.lang.Object ref = code_;
-        if (ref instanceof java.lang.String string) {
-          return string;
+        if (ref instanceof java.lang.String) {
+          return (java.lang.String) ref;
         } else {
           com.google.protobuf.ByteString bs = 
               (com.google.protobuf.ByteString) ref;
@@ -1689,10 +1754,10 @@ public final class RegArimaSpec extends
       public com.google.protobuf.ByteString
           getCodeBytes() {
         java.lang.Object ref = code_;
-        if (ref instanceof java.lang.String string) {
+        if (ref instanceof java.lang.String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  string);
+                  (java.lang.String) ref);
           code_ = b;
           return b;
         } else {
@@ -1959,8 +2024,8 @@ public final class RegArimaSpec extends
 
         @java.lang.Override
         public Builder mergeFrom(com.google.protobuf.Message other) {
-          if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.OutlierSpec.Type type) {
-            return mergeFrom(type);
+          if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.OutlierSpec.Type) {
+            return mergeFrom((jdplus.x13.base.protobuf.RegArimaSpec.OutlierSpec.Type)other);
           } else {
             super.mergeFrom(other);
             return this;
@@ -2054,10 +2119,10 @@ public final class RegArimaSpec extends
         public com.google.protobuf.ByteString
             getCodeBytes() {
           java.lang.Object ref = code_;
-          if (ref instanceof java.lang.String string) {
+          if (ref instanceof String) {
             com.google.protobuf.ByteString b = 
                 com.google.protobuf.ByteString.copyFromUtf8(
-                    string);
+                    (java.lang.String) ref);
             code_ = b;
             return b;
           } else {
@@ -2679,8 +2744,8 @@ public final class RegArimaSpec extends
 
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.OutlierSpec spec) {
-          return mergeFrom(spec);
+        if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.OutlierSpec) {
+          return mergeFrom((jdplus.x13.base.protobuf.RegArimaSpec.OutlierSpec)other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -3497,8 +3562,7 @@ public final class RegArimaSpec extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:x13.RegArimaSpec.AutoModelSpec)
       AutoModelSpecOrBuilder {
-      @Serial
-      private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     static {
       com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
         com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -4077,8 +4141,8 @@ public final class RegArimaSpec extends
 
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.AutoModelSpec spec) {
-          return mergeFrom(spec);
+        if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.AutoModelSpec) {
+          return mergeFrom((jdplus.x13.base.protobuf.RegArimaSpec.AutoModelSpec)other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -4715,8 +4779,7 @@ public final class RegArimaSpec extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:x13.RegArimaSpec.EasterSpec)
       EasterSpecOrBuilder {
-      @Serial
-      private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     static {
       com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
         com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -5117,8 +5180,8 @@ public final class RegArimaSpec extends
 
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.EasterSpec spec) {
-          return mergeFrom(spec);
+        if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.EasterSpec) {
+          return mergeFrom((jdplus.x13.base.protobuf.RegArimaSpec.EasterSpec)other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -5669,8 +5732,7 @@ public final class RegArimaSpec extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:x13.RegArimaSpec.TradingDaysSpec)
       TradingDaysSpecOrBuilder {
-      @Serial
-      private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     static {
       com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
         com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -5755,8 +5817,8 @@ public final class RegArimaSpec extends
     @java.lang.Override
     public java.lang.String getHolidays() {
       java.lang.Object ref = holidays_;
-      if (ref instanceof java.lang.String string) {
-        return string;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
@@ -5773,10 +5835,10 @@ public final class RegArimaSpec extends
     public com.google.protobuf.ByteString
         getHolidaysBytes() {
       java.lang.Object ref = holidays_;
-      if (ref instanceof java.lang.String string) {
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                string);
+                (java.lang.String) ref);
         holidays_ = b;
         return b;
       } else {
@@ -6412,8 +6474,8 @@ public final class RegArimaSpec extends
 
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.TradingDaysSpec spec) {
-          return mergeFrom(spec);
+        if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.TradingDaysSpec) {
+          return mergeFrom((jdplus.x13.base.protobuf.RegArimaSpec.TradingDaysSpec)other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -6734,10 +6796,10 @@ public final class RegArimaSpec extends
       public com.google.protobuf.ByteString
           getHolidaysBytes() {
         java.lang.Object ref = holidays_;
-        if (ref instanceof java.lang.String string) {
+        if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  string);
+                  (java.lang.String) ref);
           holidays_ = b;
           return b;
         } else {
@@ -6873,7 +6935,7 @@ public final class RegArimaSpec extends
       public Builder clearUsers() {
         users_ =
           com.google.protobuf.LazyStringArrayList.emptyList();
-        bitField0_ = (bitField0_ & ~0x00000008);
+        bitField0_ = (bitField0_ & ~0x00000008);;
         onChanged();
         return this;
       }
@@ -7697,8 +7759,7 @@ public final class RegArimaSpec extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:x13.RegArimaSpec.RegressionSpec)
       RegressionSpecOrBuilder {
-      @Serial
-      private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     static {
       com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
         com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -8434,8 +8495,8 @@ public final class RegArimaSpec extends
 
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.RegressionSpec spec) {
-          return mergeFrom(spec);
+        if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.RegressionSpec) {
+          return mergeFrom((jdplus.x13.base.protobuf.RegArimaSpec.RegressionSpec)other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -10119,8 +10180,7 @@ public final class RegArimaSpec extends
       com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:x13.RegArimaSpec.EstimateSpec)
       EstimateSpecOrBuilder {
-      @Serial
-      private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
     static {
       com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
         com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -10457,8 +10517,8 @@ public final class RegArimaSpec extends
 
       @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.EstimateSpec spec) {
-          return mergeFrom(spec);
+        if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec.EstimateSpec) {
+          return mergeFrom((jdplus.x13.base.protobuf.RegArimaSpec.EstimateSpec)other);
         } else {
           super.mergeFrom(other);
           return this;
@@ -11335,8 +11395,8 @@ public final class RegArimaSpec extends
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec spec) {
-        return mergeFrom(spec);
+      if (other instanceof jdplus.x13.base.protobuf.RegArimaSpec) {
+        return mergeFrom((jdplus.x13.base.protobuf.RegArimaSpec)other);
       } else {
         super.mergeFrom(other);
         return this;

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/RegressionTest.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/RegressionTest.java
@@ -71,12 +71,12 @@ public enum RegressionTest
    * @return The enum associated with the given numeric wire value.
    */
   public static RegressionTest forNumber(int value) {
-    return switch (value) {
-      case 0 -> TEST_NO;
-      case 1 -> TEST_ADD;
-      case 2 -> TEST_REMOVE;
-      default -> null;
-    };
+    switch (value) {
+      case 0: return TEST_NO;
+      case 1: return TEST_ADD;
+      case 2: return TEST_REMOVE;
+      default: return null;
+    }
   }
 
   public static com.google.protobuf.Internal.EnumLiteMap<RegressionTest>

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/SeasonalFilter.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/SeasonalFilter.java
@@ -111,17 +111,17 @@ public enum SeasonalFilter
    * @return The enum associated with the given numeric wire value.
    */
   public static SeasonalFilter forNumber(int value) {
-    return switch (value) {
-      case 0 -> SEASONAL_FILTER_MSR;
-      case 1 -> SEASONAL_FILTER_S3X1;
-      case 2 -> SEASONAL_FILTER_S3X3;
-      case 3 -> SEASONAL_FILTER_S3X5;
-      case 4 -> SEASONAL_FILTER_S3X9;
-      case 5 -> SEASONAL_FILTER_S3X15;
-      case 6 -> SEASONAL_FILTER_STABLE;
-      case 7 -> SEASONAL_FILTER_X11DEFAULT;
-      default -> null;
-    };
+    switch (value) {
+      case 0: return SEASONAL_FILTER_MSR;
+      case 1: return SEASONAL_FILTER_S3X1;
+      case 2: return SEASONAL_FILTER_S3X3;
+      case 3: return SEASONAL_FILTER_S3X5;
+      case 4: return SEASONAL_FILTER_S3X9;
+      case 5: return SEASONAL_FILTER_S3X15;
+      case 6: return SEASONAL_FILTER_STABLE;
+      case 7: return SEASONAL_FILTER_X11DEFAULT;
+      default: return null;
+    }
   }
 
   public static com.google.protobuf.Internal.EnumLiteMap<SeasonalFilter>

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/Spec.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/Spec.java
@@ -5,8 +5,6 @@
 
 package jdplus.x13.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code x13.Spec}
  */
@@ -14,8 +12,7 @@ public final class Spec extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:x13.Spec)
     SpecOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -432,8 +429,8 @@ public final class Spec extends
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.x13.base.protobuf.Spec spec) {
-        return mergeFrom(spec);
+      if (other instanceof jdplus.x13.base.protobuf.Spec) {
+        return mergeFrom((jdplus.x13.base.protobuf.Spec)other);
       } else {
         super.mergeFrom(other);
         return this;

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/X11Results.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/X11Results.java
@@ -5,8 +5,6 @@
 
 package jdplus.x13.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code x13.X11Results}
  */
@@ -14,8 +12,7 @@ public final class X11Results extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:x13.X11Results)
     X11ResultsOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -2515,8 +2512,8 @@ public final class X11Results extends
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.x13.base.protobuf.X11Results results) {
-        return mergeFrom(results);
+      if (other instanceof jdplus.x13.base.protobuf.X11Results) {
+        return mergeFrom((jdplus.x13.base.protobuf.X11Results)other);
       } else {
         super.mergeFrom(other);
         return this;

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/X11Spec.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/X11Spec.java
@@ -5,8 +5,6 @@
 
 package jdplus.x13.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code x13.X11Spec}
  */
@@ -14,8 +12,7 @@ public final class X11Spec extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:x13.X11Spec)
     X11SpecOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -707,8 +704,8 @@ public final class X11Spec extends
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.x13.base.protobuf.X11Spec spec) {
-        return mergeFrom(spec);
+      if (other instanceof jdplus.x13.base.protobuf.X11Spec) {
+        return mergeFrom((jdplus.x13.base.protobuf.X11Spec)other);
       } else {
         super.mergeFrom(other);
         return this;

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/X13Finals.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/X13Finals.java
@@ -5,8 +5,6 @@
 
 package jdplus.x13.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code x13.X13Finals}
  */
@@ -14,8 +12,7 @@ public final class X13Finals extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:x13.X13Finals)
     X13FinalsOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -972,8 +969,8 @@ public final class X13Finals extends
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.x13.base.protobuf.X13Finals finals) {
-        return mergeFrom(finals);
+      if (other instanceof jdplus.x13.base.protobuf.X13Finals) {
+        return mergeFrom((jdplus.x13.base.protobuf.X13Finals)other);
       } else {
         super.mergeFrom(other);
         return this;

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/X13Output.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/X13Output.java
@@ -5,8 +5,6 @@
 
 package jdplus.x13.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code x13.X13Output}
  */
@@ -14,8 +12,7 @@ public final class X13Output extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:x13.X13Output)
     X13OutputOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -625,8 +622,8 @@ jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail defaultValue
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.x13.base.protobuf.X13Output output) {
-        return mergeFrom(output);
+      if (other instanceof jdplus.x13.base.protobuf.X13Output) {
+        return mergeFrom((jdplus.x13.base.protobuf.X13Output)other);
       } else {
         super.mergeFrom(other);
         return this;
@@ -1217,7 +1214,7 @@ jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail defaultValue
     private static final class DetailsConverter implements com.google.protobuf.MapFieldBuilder.Converter<java.lang.String, jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetailOrBuilder, jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail> {
       @java.lang.Override
       public jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail build(jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetailOrBuilder val) {
-        if (val instanceof jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail detail) { return detail; }
+        if (val instanceof jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail) { return (jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail) val; }
         return ((jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail.Builder) val).build();
       }
 
@@ -1225,7 +1222,7 @@ jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail defaultValue
       public com.google.protobuf.MapEntry<java.lang.String, jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail> defaultEntry() {
         return DetailsDefaultEntryHolder.defaultEntry;
       }
-    }
+    };
     private static final DetailsConverter detailsConverter = new DetailsConverter();
 
     private com.google.protobuf.MapFieldBuilder<
@@ -1362,8 +1359,8 @@ jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail defaultValue
         entry = jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail.newBuilder();
         builderMap.put(key, entry);
       }
-      if (entry instanceof jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail detail) {
-        entry = detail.toBuilder();
+      if (entry instanceof jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail) {
+        entry = ((jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail) entry).toBuilder();
         builderMap.put(key, entry);
       }
       return (jdplus.toolkit.base.protobuf.toolkit.ToolkitProtos.ProcessingDetail.Builder) entry;

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/X13Preadjustment.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/X13Preadjustment.java
@@ -5,8 +5,6 @@
 
 package jdplus.x13.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code x13.X13Preadjustment}
  */
@@ -14,8 +12,7 @@ public final class X13Preadjustment extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:x13.X13Preadjustment)
     X13PreadjustmentOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -648,8 +645,8 @@ public final class X13Preadjustment extends
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.x13.base.protobuf.X13Preadjustment preadjustment) {
-        return mergeFrom(preadjustment);
+      if (other instanceof jdplus.x13.base.protobuf.X13Preadjustment) {
+        return mergeFrom((jdplus.x13.base.protobuf.X13Preadjustment)other);
       } else {
         super.mergeFrom(other);
         return this;

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/X13Protos.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/X13Protos.java
@@ -153,7 +153,7 @@ public final class X13Protos {
       "\007 \001(\005\022\017\n\007nbcasts\030\010 \001(\005\022!\n\005sigma\030\t \001(\0162\022." +
       "x13.CalendarSigma\022\017\n\007vsigmas\030\n \003(\005\022\026\n\016ex" +
       "clude_fcasts\030\013 \001(\010\022!\n\004bias\030\014 \001(\0162\023.x13.B" +
-      "iasCorrection\"\210\017\n\014RegArimaSpec\022*\n\005basic\030" +
+      "iasCorrection\"\242\017\n\014RegArimaSpec\022*\n\005basic\030" +
       "\001 \001(\0132\033.x13.RegArimaSpec.BasicSpec\0222\n\ttr" +
       "ansform\030\002 \001(\0132\037.x13.RegArimaSpec.Transfo" +
       "rmSpec\022.\n\007outlier\030\003 \001(\0132\035.x13.RegArimaSp" +
@@ -162,140 +162,140 @@ public final class X13Protos {
       "ArimaSpec.AutoModelSpec\0224\n\nregression\030\006 " +
       "\001(\0132 .x13.RegArimaSpec.RegressionSpec\0220\n" +
       "\010estimate\030\007 \001(\0132\036.x13.RegArimaSpec.Estim" +
-      "ateSpec\032^\n\tBasicSpec\022\037\n\004span\030\001 \001(\0132\021.jd3" +
+      "ateSpec\032x\n\tBasicSpec\022\037\n\004span\030\001 \001(\0132\021.jd3" +
       ".TimeSelector\022\025\n\rpreprocessing\030\002 \001(\010\022\031\n\021" +
-      "preliminary_check\030\003 \001(\010\032\233\001\n\rTransformSpe" +
-      "c\0221\n\016transformation\030\001 \001(\0162\031.modelling.Tr" +
-      "ansformation\022)\n\006adjust\030\002 \001(\0162\031.modelling" +
-      ".LengthOfPeriod\022\017\n\007aicdiff\030\003 \001(\001\022\033\n\023outl" +
-      "iers_correction\030\004 \001(\010\032\362\001\n\013OutlierSpec\0224\n" +
-      "\010outliers\030\001 \003(\0132\".x13.RegArimaSpec.Outli" +
-      "erSpec.Type\022\037\n\004span\030\002 \001(\0132\021.jd3.TimeSele" +
-      "ctor\022\r\n\005defva\030\003 \001(\001\022\"\n\006method\030\004 \001(\0162\022.x1" +
-      "3.OutlierMethod\022\027\n\017monthly_tc_rate\030\005 \001(\001" +
-      "\022\017\n\007maxiter\030\006 \001(\005\022\r\n\005lsrun\030\007 \001(\005\032 \n\004Type" +
-      "\022\014\n\004code\030\001 \001(\t\022\n\n\002va\030\002 \001(\001\032\314\001\n\rAutoModel" +
-      "Spec\022\017\n\007enabled\030\001 \001(\010\022\020\n\010ljungbox\030\002 \001(\001\022" +
-      "\014\n\004tsig\030\003 \001(\001\022\016\n\006predcv\030\004 \001(\001\022\017\n\007ubfinal" +
-      "\030\005 \001(\001\022\013\n\003ub1\030\006 \001(\001\022\013\n\003ub2\030\007 \001(\001\022\016\n\006canc" +
-      "el\030\010 \001(\001\022\013\n\003fct\030\t \001(\001\022\021\n\tacceptdef\030\n \001(\010" +
-      "\022\r\n\005mixed\030\013 \001(\010\022\020\n\010balanced\030\014 \001(\010\032\205\001\n\nEa" +
-      "sterSpec\022\035\n\004type\030\001 \001(\0162\017.x13.EasterType\022" +
-      "\020\n\010duration\030\002 \001(\005\022!\n\004test\030\003 \001(\0162\023.x13.Re" +
-      "gressionTest\022#\n\013coefficient\030\n \001(\0132\016.jd3." +
-      "Parameter\032\330\002\n\017TradingDaysSpec\022\"\n\002td\030\001 \001(" +
-      "\0162\026.modelling.TradingDays\022%\n\002lp\030\002 \001(\0162\031." +
-      "modelling.LengthOfPeriod\022\020\n\010holidays\030\003 \001" +
-      "(\t\022\r\n\005users\030\004 \003(\t\022\t\n\001w\030\005 \001(\005\022!\n\004test\030\006 \001" +
-      "(\0162\023.x13.RegressionTest\022\'\n\004auto\030\007 \001(\0162\031." +
-      "x13.AutomaticTradingDays\022\016\n\006ptest1\030\010 \001(\001" +
-      "\022\016\n\006ptest2\030\t \001(\001\022\023\n\013auto_adjust\030\n \001(\010\022&\n" +
-      "\016tdcoefficients\030\013 \003(\0132\016.jd3.Parameter\022%\n" +
-      "\rlpcoefficient\030\014 \001(\0132\016.jd3.Parameter\032\303\002\n" +
-      "\016RegressionSpec\022\034\n\004mean\030\001 \001(\0132\016.jd3.Para" +
-      "meter\022\022\n\ncheck_mean\030\002 \001(\010\022-\n\002td\030\003 \001(\0132!." +
-      "x13.RegArimaSpec.TradingDaysSpec\022,\n\006east" +
-      "er\030\004 \001(\0132\034.x13.RegArimaSpec.EasterSpec\022$" +
-      "\n\010outliers\030\005 \003(\0132\022.modelling.Outlier\022$\n\005" +
-      "users\030\006 \003(\0132\025.modelling.TsVariable\0226\n\rin" +
-      "terventions\030\007 \003(\0132\037.modelling.Interventi" +
-      "onVariable\022\036\n\005ramps\030\010 \003(\0132\017.modelling.Ra" +
-      "mp\032<\n\014EstimateSpec\022\037\n\004span\030\001 \001(\0132\021.jd3.T" +
-      "imeSelector\022\013\n\003tol\030\002 \001(\001\"r\n\004Spec\022#\n\010rega" +
-      "rima\030\001 \001(\0132\021.x13.RegArimaSpec\022\031\n\003x11\030\002 \001" +
-      "(\0132\014.x13.X11Spec\022*\n\014benchmarking\030\003 \001(\0132\024" +
-      ".sa.BenchmarkingSpec\"\334\010\n\nX11Results\022$\n\004m" +
-      "ode\030\001 \001(\0162\026.x13.DecompositionMode\022\027\n\002d1\030" +
-      "\002 \001(\0132\013.jd3.TsData\022\027\n\002d2\030\003 \001(\0132\013.jd3.TsD" +
-      "ata\022\027\n\002d4\030\004 \001(\0132\013.jd3.TsData\022\027\n\002d5\030\005 \001(\013" +
-      "2\013.jd3.TsData\022\027\n\002d6\030\006 \001(\0132\013.jd3.TsData\022\027" +
-      "\n\002d7\030\007 \001(\0132\013.jd3.TsData\022\027\n\002d8\030\010 \001(\0132\013.jd" +
-      "3.TsData\022\027\n\002d9\030\t \001(\0132\013.jd3.TsData\022\030\n\003d10" +
-      "\030\n \001(\0132\013.jd3.TsData\022\030\n\003d11\030\013 \001(\0132\013.jd3.T" +
-      "sData\022\030\n\003d12\030\014 \001(\0132\013.jd3.TsData\022\030\n\003d13\030\r" +
-      " \001(\0132\013.jd3.TsData\0223\n\026final_seasonal_filt" +
-      "ers\030\016 \003(\0162\023.x13.SeasonalFilter\022\036\n\026final_" +
-      "henderson_filter\030\017 \001(\005\022\017\n\007icratio\030\020 \001(\001\022" +
-      "\027\n\002b1\030\024 \001(\0132\013.jd3.TsData\022\027\n\002b2\030\025 \001(\0132\013.j" +
-      "d3.TsData\022\027\n\002b3\030\026 \001(\0132\013.jd3.TsData\022\027\n\002b4" +
-      "\030\027 \001(\0132\013.jd3.TsData\022\027\n\002b5\030\030 \001(\0132\013.jd3.Ts" +
-      "Data\022\027\n\002b6\030\031 \001(\0132\013.jd3.TsData\022\027\n\002b7\030\032 \001(" +
-      "\0132\013.jd3.TsData\022\027\n\002b8\030\033 \001(\0132\013.jd3.TsData\022" +
-      "\027\n\002b9\030\034 \001(\0132\013.jd3.TsData\022\030\n\003b10\030\035 \001(\0132\013." +
-      "jd3.TsData\022\030\n\003b11\030\036 \001(\0132\013.jd3.TsData\022\030\n\003" +
-      "b13\030\037 \001(\0132\013.jd3.TsData\022\030\n\003b17\030  \001(\0132\013.jd" +
-      "3.TsData\022\030\n\003b20\030! \001(\0132\013.jd3.TsData\022\027\n\002c1" +
-      "\030( \001(\0132\013.jd3.TsData\022\027\n\002c2\030) \001(\0132\013.jd3.Ts" +
-      "Data\022\027\n\002c4\030* \001(\0132\013.jd3.TsData\022\027\n\002c5\030+ \001(" +
-      "\0132\013.jd3.TsData\022\027\n\002c6\030, \001(\0132\013.jd3.TsData\022" +
-      "\027\n\002c7\030- \001(\0132\013.jd3.TsData\022\027\n\002c9\030. \001(\0132\013.j" +
-      "d3.TsData\022\030\n\003c10\030/ \001(\0132\013.jd3.TsData\022\030\n\003c" +
-      "11\0300 \001(\0132\013.jd3.TsData\022\030\n\003c13\0301 \001(\0132\013.jd3" +
-      ".TsData\022\030\n\003c17\0302 \001(\0132\013.jd3.TsData\022\030\n\003c20" +
-      "\0303 \001(\0132\013.jd3.TsData\"\253\001\n\013MStatistics\022\n\n\002m" +
-      "1\030\001 \001(\001\022\n\n\002m2\030\002 \001(\001\022\n\n\002m3\030\003 \001(\001\022\n\n\002m4\030\004 " +
-      "\001(\001\022\n\n\002m5\030\005 \001(\001\022\n\n\002m6\030\006 \001(\001\022\n\n\002m7\030\007 \001(\001\022" +
-      "\n\n\002m8\030\010 \001(\001\022\n\n\002m9\030\t \001(\001\022\013\n\003m10\030\n \001(\001\022\013\n\003" +
-      "m11\030\013 \001(\001\022\t\n\001q\030\014 \001(\001\022\013\n\003qm2\030\r \001(\001\"\303\001\n\020X1" +
-      "3Preadjustment\022\027\n\002a1\030\001 \001(\0132\013.jd3.TsData\022" +
-      "\030\n\003a1a\030\002 \001(\0132\013.jd3.TsData\022\030\n\003a1b\030\003 \001(\0132\013" +
-      ".jd3.TsData\022\027\n\002a6\030\004 \001(\0132\013.jd3.TsData\022\027\n\002" +
-      "a7\030\005 \001(\0132\013.jd3.TsData\022\027\n\002a8\030\006 \001(\0132\013.jd3." +
-      "TsData\022\027\n\002a9\030\007 \001(\0132\013.jd3.TsData\"\355\002\n\tX13F" +
-      "inals\022\035\n\010d11final\030\001 \001(\0132\013.jd3.TsData\022\035\n\010" +
-      "d12final\030\002 \001(\0132\013.jd3.TsData\022\035\n\010d13final\030" +
-      "\003 \001(\0132\013.jd3.TsData\022\030\n\003d16\030\004 \001(\0132\013.jd3.Ts" +
-      "Data\022\030\n\003d18\030\005 \001(\0132\013.jd3.TsData\022\031\n\004d11a\030\006" +
-      " \001(\0132\013.jd3.TsData\022\031\n\004d12a\030\007 \001(\0132\013.jd3.Ts" +
-      "Data\022\031\n\004d16a\030\010 \001(\0132\013.jd3.TsData\022\031\n\004d18a\030" +
-      "\t \001(\0132\013.jd3.TsData\022\027\n\002e1\030\n \001(\0132\013.jd3.TsD" +
-      "ata\022\027\n\002e2\030\013 \001(\0132\013.jd3.TsData\022\027\n\002e3\030\014 \001(\013" +
-      "2\013.jd3.TsData\022\030\n\003e11\030\r \001(\0132\013.jd3.TsData\"" +
-      "4\n\013Diagnostics\022%\n\013mstatistics\030\001 \001(\0132\020.x1" +
-      "3.MStatistics\"\205\002\n\nX13Results\022,\n\rpreadjus" +
-      "tment\030\001 \001(\0132\025.x13.X13Preadjustment\022.\n\rpr" +
-      "eprocessing\030\002 \001(\0132\027.regarima.RegArimaMod" +
-      "el\022&\n\rdecomposition\030\003 \001(\0132\017.x13.X11Resul" +
-      "ts\022\035\n\005final\030\004 \001(\0132\016.x13.X13Finals\022)\n\017dia" +
-      "gnostics_x13\030\005 \001(\0132\020.x13.Diagnostics\022\'\n\016" +
-      "diagnostics_sa\030\006 \001(\0132\017.sa.Diagnostics\"\251\002" +
-      "\n\016RegArimaOutput\022\'\n\006result\030\001 \001(\0132\027.regar" +
-      "ima.RegArimaModel\022*\n\017estimation_spec\030\002 \001" +
-      "(\0132\021.x13.RegArimaSpec\022&\n\013result_spec\030\003 \001" +
-      "(\0132\021.x13.RegArimaSpec\022 \n\003log\030\004 \001(\0132\023.jd3" +
-      ".ProcessingLogs\0221\n\007details\030\005 \003(\0132 .x13.R" +
-      "egArimaOutput.DetailsEntry\032E\n\014DetailsEnt" +
-      "ry\022\013\n\003key\030\001 \001(\t\022$\n\005value\030\002 \001(\0132\025.jd3.Pro" +
-      "cessingDetail:\0028\001\"\207\002\n\tX13Output\022\037\n\006resul" +
-      "t\030\001 \001(\0132\017.x13.X13Results\022\"\n\017estimation_s" +
-      "pec\030\002 \001(\0132\t.x13.Spec\022\036\n\013result_spec\030\003 \001(" +
-      "\0132\t.x13.Spec\022 \n\003log\030\004 \001(\0132\023.jd3.Processi" +
-      "ngLogs\022,\n\007details\030\005 \003(\0132\033.x13.X13Output." +
+      "preliminary_check\030\003 \001(\010\022\030\n\020annual_freque" +
+      "ncy\030\004 \001(\005\032\233\001\n\rTransformSpec\0221\n\016transform" +
+      "ation\030\001 \001(\0162\031.modelling.Transformation\022)" +
+      "\n\006adjust\030\002 \001(\0162\031.modelling.LengthOfPerio" +
+      "d\022\017\n\007aicdiff\030\003 \001(\001\022\033\n\023outliers_correctio" +
+      "n\030\004 \001(\010\032\362\001\n\013OutlierSpec\0224\n\010outliers\030\001 \003(" +
+      "\0132\".x13.RegArimaSpec.OutlierSpec.Type\022\037\n" +
+      "\004span\030\002 \001(\0132\021.jd3.TimeSelector\022\r\n\005defva\030" +
+      "\003 \001(\001\022\"\n\006method\030\004 \001(\0162\022.x13.OutlierMetho" +
+      "d\022\027\n\017monthly_tc_rate\030\005 \001(\001\022\017\n\007maxiter\030\006 " +
+      "\001(\005\022\r\n\005lsrun\030\007 \001(\005\032 \n\004Type\022\014\n\004code\030\001 \001(\t" +
+      "\022\n\n\002va\030\002 \001(\001\032\314\001\n\rAutoModelSpec\022\017\n\007enable" +
+      "d\030\001 \001(\010\022\020\n\010ljungbox\030\002 \001(\001\022\014\n\004tsig\030\003 \001(\001\022" +
+      "\016\n\006predcv\030\004 \001(\001\022\017\n\007ubfinal\030\005 \001(\001\022\013\n\003ub1\030" +
+      "\006 \001(\001\022\013\n\003ub2\030\007 \001(\001\022\016\n\006cancel\030\010 \001(\001\022\013\n\003fc" +
+      "t\030\t \001(\001\022\021\n\tacceptdef\030\n \001(\010\022\r\n\005mixed\030\013 \001(" +
+      "\010\022\020\n\010balanced\030\014 \001(\010\032\205\001\n\nEasterSpec\022\035\n\004ty" +
+      "pe\030\001 \001(\0162\017.x13.EasterType\022\020\n\010duration\030\002 " +
+      "\001(\005\022!\n\004test\030\003 \001(\0162\023.x13.RegressionTest\022#" +
+      "\n\013coefficient\030\n \001(\0132\016.jd3.Parameter\032\330\002\n\017" +
+      "TradingDaysSpec\022\"\n\002td\030\001 \001(\0162\026.modelling." +
+      "TradingDays\022%\n\002lp\030\002 \001(\0162\031.modelling.Leng" +
+      "thOfPeriod\022\020\n\010holidays\030\003 \001(\t\022\r\n\005users\030\004 " +
+      "\003(\t\022\t\n\001w\030\005 \001(\005\022!\n\004test\030\006 \001(\0162\023.x13.Regre" +
+      "ssionTest\022\'\n\004auto\030\007 \001(\0162\031.x13.AutomaticT" +
+      "radingDays\022\016\n\006ptest1\030\010 \001(\001\022\016\n\006ptest2\030\t \001" +
+      "(\001\022\023\n\013auto_adjust\030\n \001(\010\022&\n\016tdcoefficient" +
+      "s\030\013 \003(\0132\016.jd3.Parameter\022%\n\rlpcoefficient" +
+      "\030\014 \001(\0132\016.jd3.Parameter\032\303\002\n\016RegressionSpe" +
+      "c\022\034\n\004mean\030\001 \001(\0132\016.jd3.Parameter\022\022\n\ncheck" +
+      "_mean\030\002 \001(\010\022-\n\002td\030\003 \001(\0132!.x13.RegArimaSp" +
+      "ec.TradingDaysSpec\022,\n\006easter\030\004 \001(\0132\034.x13" +
+      ".RegArimaSpec.EasterSpec\022$\n\010outliers\030\005 \003" +
+      "(\0132\022.modelling.Outlier\022$\n\005users\030\006 \003(\0132\025." +
+      "modelling.TsVariable\0226\n\rinterventions\030\007 " +
+      "\003(\0132\037.modelling.InterventionVariable\022\036\n\005" +
+      "ramps\030\010 \003(\0132\017.modelling.Ramp\032<\n\014Estimate" +
+      "Spec\022\037\n\004span\030\001 \001(\0132\021.jd3.TimeSelector\022\013\n" +
+      "\003tol\030\002 \001(\001\"r\n\004Spec\022#\n\010regarima\030\001 \001(\0132\021.x" +
+      "13.RegArimaSpec\022\031\n\003x11\030\002 \001(\0132\014.x13.X11Sp" +
+      "ec\022*\n\014benchmarking\030\003 \001(\0132\024.sa.Benchmarki" +
+      "ngSpec\"\334\010\n\nX11Results\022$\n\004mode\030\001 \001(\0162\026.x1" +
+      "3.DecompositionMode\022\027\n\002d1\030\002 \001(\0132\013.jd3.Ts" +
+      "Data\022\027\n\002d2\030\003 \001(\0132\013.jd3.TsData\022\027\n\002d4\030\004 \001(" +
+      "\0132\013.jd3.TsData\022\027\n\002d5\030\005 \001(\0132\013.jd3.TsData\022" +
+      "\027\n\002d6\030\006 \001(\0132\013.jd3.TsData\022\027\n\002d7\030\007 \001(\0132\013.j" +
+      "d3.TsData\022\027\n\002d8\030\010 \001(\0132\013.jd3.TsData\022\027\n\002d9" +
+      "\030\t \001(\0132\013.jd3.TsData\022\030\n\003d10\030\n \001(\0132\013.jd3.T" +
+      "sData\022\030\n\003d11\030\013 \001(\0132\013.jd3.TsData\022\030\n\003d12\030\014" +
+      " \001(\0132\013.jd3.TsData\022\030\n\003d13\030\r \001(\0132\013.jd3.TsD" +
+      "ata\0223\n\026final_seasonal_filters\030\016 \003(\0162\023.x1" +
+      "3.SeasonalFilter\022\036\n\026final_henderson_filt" +
+      "er\030\017 \001(\005\022\017\n\007icratio\030\020 \001(\001\022\027\n\002b1\030\024 \001(\0132\013." +
+      "jd3.TsData\022\027\n\002b2\030\025 \001(\0132\013.jd3.TsData\022\027\n\002b" +
+      "3\030\026 \001(\0132\013.jd3.TsData\022\027\n\002b4\030\027 \001(\0132\013.jd3.T" +
+      "sData\022\027\n\002b5\030\030 \001(\0132\013.jd3.TsData\022\027\n\002b6\030\031 \001" +
+      "(\0132\013.jd3.TsData\022\027\n\002b7\030\032 \001(\0132\013.jd3.TsData" +
+      "\022\027\n\002b8\030\033 \001(\0132\013.jd3.TsData\022\027\n\002b9\030\034 \001(\0132\013." +
+      "jd3.TsData\022\030\n\003b10\030\035 \001(\0132\013.jd3.TsData\022\030\n\003" +
+      "b11\030\036 \001(\0132\013.jd3.TsData\022\030\n\003b13\030\037 \001(\0132\013.jd" +
+      "3.TsData\022\030\n\003b17\030  \001(\0132\013.jd3.TsData\022\030\n\003b2" +
+      "0\030! \001(\0132\013.jd3.TsData\022\027\n\002c1\030( \001(\0132\013.jd3.T" +
+      "sData\022\027\n\002c2\030) \001(\0132\013.jd3.TsData\022\027\n\002c4\030* \001" +
+      "(\0132\013.jd3.TsData\022\027\n\002c5\030+ \001(\0132\013.jd3.TsData" +
+      "\022\027\n\002c6\030, \001(\0132\013.jd3.TsData\022\027\n\002c7\030- \001(\0132\013." +
+      "jd3.TsData\022\027\n\002c9\030. \001(\0132\013.jd3.TsData\022\030\n\003c" +
+      "10\030/ \001(\0132\013.jd3.TsData\022\030\n\003c11\0300 \001(\0132\013.jd3" +
+      ".TsData\022\030\n\003c13\0301 \001(\0132\013.jd3.TsData\022\030\n\003c17" +
+      "\0302 \001(\0132\013.jd3.TsData\022\030\n\003c20\0303 \001(\0132\013.jd3.T" +
+      "sData\"\253\001\n\013MStatistics\022\n\n\002m1\030\001 \001(\001\022\n\n\002m2\030" +
+      "\002 \001(\001\022\n\n\002m3\030\003 \001(\001\022\n\n\002m4\030\004 \001(\001\022\n\n\002m5\030\005 \001(" +
+      "\001\022\n\n\002m6\030\006 \001(\001\022\n\n\002m7\030\007 \001(\001\022\n\n\002m8\030\010 \001(\001\022\n\n" +
+      "\002m9\030\t \001(\001\022\013\n\003m10\030\n \001(\001\022\013\n\003m11\030\013 \001(\001\022\t\n\001q" +
+      "\030\014 \001(\001\022\013\n\003qm2\030\r \001(\001\"\303\001\n\020X13Preadjustment" +
+      "\022\027\n\002a1\030\001 \001(\0132\013.jd3.TsData\022\030\n\003a1a\030\002 \001(\0132\013" +
+      ".jd3.TsData\022\030\n\003a1b\030\003 \001(\0132\013.jd3.TsData\022\027\n" +
+      "\002a6\030\004 \001(\0132\013.jd3.TsData\022\027\n\002a7\030\005 \001(\0132\013.jd3" +
+      ".TsData\022\027\n\002a8\030\006 \001(\0132\013.jd3.TsData\022\027\n\002a9\030\007" +
+      " \001(\0132\013.jd3.TsData\"\355\002\n\tX13Finals\022\035\n\010d11fi" +
+      "nal\030\001 \001(\0132\013.jd3.TsData\022\035\n\010d12final\030\002 \001(\013" +
+      "2\013.jd3.TsData\022\035\n\010d13final\030\003 \001(\0132\013.jd3.Ts" +
+      "Data\022\030\n\003d16\030\004 \001(\0132\013.jd3.TsData\022\030\n\003d18\030\005 " +
+      "\001(\0132\013.jd3.TsData\022\031\n\004d11a\030\006 \001(\0132\013.jd3.TsD" +
+      "ata\022\031\n\004d12a\030\007 \001(\0132\013.jd3.TsData\022\031\n\004d16a\030\010" +
+      " \001(\0132\013.jd3.TsData\022\031\n\004d18a\030\t \001(\0132\013.jd3.Ts" +
+      "Data\022\027\n\002e1\030\n \001(\0132\013.jd3.TsData\022\027\n\002e2\030\013 \001(" +
+      "\0132\013.jd3.TsData\022\027\n\002e3\030\014 \001(\0132\013.jd3.TsData\022" +
+      "\030\n\003e11\030\r \001(\0132\013.jd3.TsData\"4\n\013Diagnostics" +
+      "\022%\n\013mstatistics\030\001 \001(\0132\020.x13.MStatistics\"" +
+      "\205\002\n\nX13Results\022,\n\rpreadjustment\030\001 \001(\0132\025." +
+      "x13.X13Preadjustment\022.\n\rpreprocessing\030\002 " +
+      "\001(\0132\027.regarima.RegArimaModel\022&\n\rdecompos" +
+      "ition\030\003 \001(\0132\017.x13.X11Results\022\035\n\005final\030\004 " +
+      "\001(\0132\016.x13.X13Finals\022)\n\017diagnostics_x13\030\005" +
+      " \001(\0132\020.x13.Diagnostics\022\'\n\016diagnostics_sa" +
+      "\030\006 \001(\0132\017.sa.Diagnostics\"\251\002\n\016RegArimaOutp" +
+      "ut\022\'\n\006result\030\001 \001(\0132\027.regarima.RegArimaMo" +
+      "del\022*\n\017estimation_spec\030\002 \001(\0132\021.x13.RegAr" +
+      "imaSpec\022&\n\013result_spec\030\003 \001(\0132\021.x13.RegAr" +
+      "imaSpec\022 \n\003log\030\004 \001(\0132\023.jd3.ProcessingLog" +
+      "s\0221\n\007details\030\005 \003(\0132 .x13.RegArimaOutput." +
       "DetailsEntry\032E\n\014DetailsEntry\022\013\n\003key\030\001 \001(" +
       "\t\022$\n\005value\030\002 \001(\0132\025.jd3.ProcessingDetail:" +
-      "\0028\001*\200\001\n\021DecompositionMode\022\020\n\014MODE_UNKNOW" +
-      "N\020\000\022\021\n\rMODE_ADDITIVE\020\001\022\027\n\023MODE_MULTIPLIC" +
-      "ATIVE\020\002\022\024\n\020MODE_LOGADDITIVE\020\003\022\027\n\023MODE_PS" +
-      "EUDOADDITIVE\020\004*\350\001\n\016SeasonalFilter\022\027\n\023SEA" +
-      "SONAL_FILTER_MSR\020\000\022\030\n\024SEASONAL_FILTER_S3" +
-      "X1\020\001\022\030\n\024SEASONAL_FILTER_S3X3\020\002\022\030\n\024SEASON" +
-      "AL_FILTER_S3X5\020\003\022\030\n\024SEASONAL_FILTER_S3X9" +
-      "\020\004\022\031\n\025SEASONAL_FILTER_S3X15\020\005\022\032\n\026SEASONA" +
-      "L_FILTER_STABLE\020\006\022\036\n\032SEASONAL_FILTER_X11" +
-      "DEFAULT\020\007*R\n\rCalendarSigma\022\016\n\nSIGMA_NONE" +
-      "\020\000\022\020\n\014SIGMA_SIGNIF\020\001\022\r\n\tSIGMA_ALL\020\002\022\020\n\014S" +
-      "IGMA_SELECT\020\003*Q\n\016BiasCorrection\022\r\n\tBIAS_" +
-      "NONE\020\000\022\017\n\013BIAS_LEGACY\020\001\022\017\n\013BIAS_SMOOTH\020\002" +
-      "\022\016\n\nBIAS_RATIO\020\003*7\n\rOutlierMethod\022\022\n\016OUT" +
-      "LIER_ADDONE\020\000\022\022\n\016OUTLIER_ADDALL\020\001*V\n\nEas" +
-      "terType\022\021\n\rEASTER_UNUSED\020\000\022\023\n\017EASTER_STA" +
-      "NDARD\020\001\022\021\n\rEASTER_JULIAN\020\002\022\r\n\tEASTER_SC\020" +
-      "\003*<\n\016RegressionTest\022\013\n\007TEST_NO\020\000\022\014\n\010TEST" +
-      "_ADD\020\001\022\017\n\013TEST_REMOVE\020\002*Z\n\024AutomaticTrad" +
-      "ingDays\022\016\n\nTD_AUTO_NO\020\000\022\020\n\014TD_AUTO_WALD\020" +
-      "\001\022\017\n\013TD_AUTO_AIC\020\002\022\017\n\013TD_AUTO_BIC\020\003B\'\n\030j" +
-      "dplus.x13.base.protobufB\tX13ProtosP\001P\000P\001" +
-      "P\002P\003b\006proto3"
+      "\0028\001\"\207\002\n\tX13Output\022\037\n\006result\030\001 \001(\0132\017.x13." +
+      "X13Results\022\"\n\017estimation_spec\030\002 \001(\0132\t.x1" +
+      "3.Spec\022\036\n\013result_spec\030\003 \001(\0132\t.x13.Spec\022 " +
+      "\n\003log\030\004 \001(\0132\023.jd3.ProcessingLogs\022,\n\007deta" +
+      "ils\030\005 \003(\0132\033.x13.X13Output.DetailsEntry\032E" +
+      "\n\014DetailsEntry\022\013\n\003key\030\001 \001(\t\022$\n\005value\030\002 \001" +
+      "(\0132\025.jd3.ProcessingDetail:\0028\001*\200\001\n\021Decomp" +
+      "ositionMode\022\020\n\014MODE_UNKNOWN\020\000\022\021\n\rMODE_AD" +
+      "DITIVE\020\001\022\027\n\023MODE_MULTIPLICATIVE\020\002\022\024\n\020MOD" +
+      "E_LOGADDITIVE\020\003\022\027\n\023MODE_PSEUDOADDITIVE\020\004" +
+      "*\350\001\n\016SeasonalFilter\022\027\n\023SEASONAL_FILTER_M" +
+      "SR\020\000\022\030\n\024SEASONAL_FILTER_S3X1\020\001\022\030\n\024SEASON" +
+      "AL_FILTER_S3X3\020\002\022\030\n\024SEASONAL_FILTER_S3X5" +
+      "\020\003\022\030\n\024SEASONAL_FILTER_S3X9\020\004\022\031\n\025SEASONAL" +
+      "_FILTER_S3X15\020\005\022\032\n\026SEASONAL_FILTER_STABL" +
+      "E\020\006\022\036\n\032SEASONAL_FILTER_X11DEFAULT\020\007*R\n\rC" +
+      "alendarSigma\022\016\n\nSIGMA_NONE\020\000\022\020\n\014SIGMA_SI" +
+      "GNIF\020\001\022\r\n\tSIGMA_ALL\020\002\022\020\n\014SIGMA_SELECT\020\003*" +
+      "Q\n\016BiasCorrection\022\r\n\tBIAS_NONE\020\000\022\017\n\013BIAS" +
+      "_LEGACY\020\001\022\017\n\013BIAS_SMOOTH\020\002\022\016\n\nBIAS_RATIO" +
+      "\020\003*7\n\rOutlierMethod\022\022\n\016OUTLIER_ADDONE\020\000\022" +
+      "\022\n\016OUTLIER_ADDALL\020\001*V\n\nEasterType\022\021\n\rEAS" +
+      "TER_UNUSED\020\000\022\023\n\017EASTER_STANDARD\020\001\022\021\n\rEAS" +
+      "TER_JULIAN\020\002\022\r\n\tEASTER_SC\020\003*<\n\016Regressio" +
+      "nTest\022\013\n\007TEST_NO\020\000\022\014\n\010TEST_ADD\020\001\022\017\n\013TEST" +
+      "_REMOVE\020\002*Z\n\024AutomaticTradingDays\022\016\n\nTD_" +
+      "AUTO_NO\020\000\022\020\n\014TD_AUTO_WALD\020\001\022\017\n\013TD_AUTO_A" +
+      "IC\020\002\022\017\n\013TD_AUTO_BIC\020\003B\'\n\030jdplus.x13.base" +
+      ".protobufB\tX13ProtosP\001P\000P\001P\002P\003b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -306,7 +306,7 @@ public final class X13Protos {
           jdplus.sa.base.protobuf.SaProtos.getDescriptor(),
         });
     internal_static_x13_X11Spec_descriptor =
-      getDescriptor().getMessageTypes().getFirst();
+      getDescriptor().getMessageTypes().get(0);
     internal_static_x13_X11Spec_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_x13_X11Spec_descriptor,
@@ -318,11 +318,11 @@ public final class X13Protos {
         internal_static_x13_RegArimaSpec_descriptor,
         new java.lang.String[] { "Basic", "Transform", "Outlier", "Arima", "Automodel", "Regression", "Estimate", });
     internal_static_x13_RegArimaSpec_BasicSpec_descriptor =
-      internal_static_x13_RegArimaSpec_descriptor.getNestedTypes().getFirst();
+      internal_static_x13_RegArimaSpec_descriptor.getNestedTypes().get(0);
     internal_static_x13_RegArimaSpec_BasicSpec_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_x13_RegArimaSpec_BasicSpec_descriptor,
-        new java.lang.String[] { "Span", "Preprocessing", "PreliminaryCheck", });
+        new java.lang.String[] { "Span", "Preprocessing", "PreliminaryCheck", "AnnualFrequency", });
     internal_static_x13_RegArimaSpec_TransformSpec_descriptor =
       internal_static_x13_RegArimaSpec_descriptor.getNestedTypes().get(1);
     internal_static_x13_RegArimaSpec_TransformSpec_fieldAccessorTable = new
@@ -336,7 +336,7 @@ public final class X13Protos {
         internal_static_x13_RegArimaSpec_OutlierSpec_descriptor,
         new java.lang.String[] { "Outliers", "Span", "Defva", "Method", "MonthlyTcRate", "Maxiter", "Lsrun", });
     internal_static_x13_RegArimaSpec_OutlierSpec_Type_descriptor =
-      internal_static_x13_RegArimaSpec_OutlierSpec_descriptor.getNestedTypes().getFirst();
+      internal_static_x13_RegArimaSpec_OutlierSpec_descriptor.getNestedTypes().get(0);
     internal_static_x13_RegArimaSpec_OutlierSpec_Type_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_x13_RegArimaSpec_OutlierSpec_Type_descriptor,
@@ -420,7 +420,7 @@ public final class X13Protos {
         internal_static_x13_RegArimaOutput_descriptor,
         new java.lang.String[] { "Result", "EstimationSpec", "ResultSpec", "Log", "Details", });
     internal_static_x13_RegArimaOutput_DetailsEntry_descriptor =
-      internal_static_x13_RegArimaOutput_descriptor.getNestedTypes().getFirst();
+      internal_static_x13_RegArimaOutput_descriptor.getNestedTypes().get(0);
     internal_static_x13_RegArimaOutput_DetailsEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_x13_RegArimaOutput_DetailsEntry_descriptor,
@@ -432,7 +432,7 @@ public final class X13Protos {
         internal_static_x13_X13Output_descriptor,
         new java.lang.String[] { "Result", "EstimationSpec", "ResultSpec", "Log", "Details", });
     internal_static_x13_X13Output_DetailsEntry_descriptor =
-      internal_static_x13_X13Output_descriptor.getNestedTypes().getFirst();
+      internal_static_x13_X13Output_descriptor.getNestedTypes().get(0);
     internal_static_x13_X13Output_DetailsEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_x13_X13Output_DetailsEntry_descriptor,

--- a/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/X13Results.java
+++ b/jdplus-main-base/jdplus-x13-base-parent/jdplus-x13-base-protobuf/src/main/java/jdplus/x13/base/protobuf/X13Results.java
@@ -5,8 +5,6 @@
 
 package jdplus.x13.base.protobuf;
 
-import java.io.Serial;
-
 /**
  * Protobuf type {@code x13.X13Results}
  */
@@ -14,8 +12,7 @@ public final class X13Results extends
     com.google.protobuf.GeneratedMessage implements
     // @@protoc_insertion_point(message_implements:x13.X13Results)
     X13ResultsOrBuilder {
-    @Serial
-    private static final long serialVersionUID = 0L;
+private static final long serialVersionUID = 0L;
   static {
     com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
       com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
@@ -594,8 +591,8 @@ public final class X13Results extends
 
     @java.lang.Override
     public Builder mergeFrom(com.google.protobuf.Message other) {
-      if (other instanceof jdplus.x13.base.protobuf.X13Results results) {
-        return mergeFrom(results);
+      if (other instanceof jdplus.x13.base.protobuf.X13Results) {
+        return mergeFrom((jdplus.x13.base.protobuf.X13Results)other);
       } else {
         super.mergeFrom(other);
         return this;

--- a/jdplus-main-desktop/jdplus-sa-desktop-plugin/src/main/java/jdplus/sa/desktop/plugin/multiprocessing/ui/SaBatchUI.java
+++ b/jdplus-main-desktop/jdplus-sa-desktop-plugin/src/main/java/jdplus/sa/desktop/plugin/multiprocessing/ui/SaBatchUI.java
@@ -831,7 +831,7 @@ public class SaBatchUI extends AbstractSaProcessingTopComponent implements Multi
             }
         } else {
             SaItem output = item.getOutput();
-            SaSpecification cspec = output.getDefinition().activeSpecification();
+            SaSpecification cspec = output.getDefinition().getEstimationSpec();
             Ts ts = output.getDefinition().getTs();
             TsDocument doc = (TsDocument) detail.getDocument();
             if (doc != null && cspec.getClass().isInstance(doc.getSpecification())) {

--- a/jdplus-main-desktop/jdplus-sa-desktop-plugin/src/main/java/jdplus/sa/desktop/plugin/multiprocessing/ui/SaNode.java
+++ b/jdplus-main-desktop/jdplus-sa-desktop-plugin/src/main/java/jdplus/sa/desktop/plugin/multiprocessing/ui/SaNode.java
@@ -93,7 +93,7 @@ public class SaNode {
 
     public static SaNode of(int id, SaItem item) {
         SaDefinition definition = item.getDefinition();
-        SaNode node = new SaNode(id, definition.getTs().getMoniker(), definition.activeSpecification());
+        SaNode node = new SaNode(id, definition.getTs().getMoniker(), definition.getEstimationSpec());
         node.output = item;
         node.status = status(item);
         return node;

--- a/jdplus-main-desktop/jdplus-toolkit-desktop-plugin/src/main/java/jdplus/toolkit/desktop/plugin/DemetraUI.java
+++ b/jdplus-main-desktop/jdplus-toolkit-desktop-plugin/src/main/java/jdplus/toolkit/desktop/plugin/DemetraUI.java
@@ -122,7 +122,7 @@ public final class DemetraUI implements PropertyChangeSource.WithWeakListeners, 
 
     @SwingProperty
     public static final String PRESPECIFIED_OUTLIERS_EDITOR_PROPERTY = "prespecifiedOutliersEditor";
-    private static final OutlierDescriptorsEditor.PrespecificiedOutliersEditor DEFAULT_PRESPECIFIED_OUTLIERS_EDITOR = OutlierDescriptorsEditor.PrespecificiedOutliersEditor.LIST;
+    private static final OutlierDescriptorsEditor.PrespecificiedOutliersEditor DEFAULT_PRESPECIFIED_OUTLIERS_EDITOR = OutlierDescriptorsEditor.PrespecificiedOutliersEditor.CALENDAR_GRID;
     private OutlierDescriptorsEditor.PrespecificiedOutliersEditor prespecifiedOutliersEditor = DEFAULT_PRESPECIFIED_OUTLIERS_EDITOR;
 
     public OutlierDescriptorsEditor.PrespecificiedOutliersEditor getPrespecifiedOutliersEditor() {

--- a/jdplus-main-desktop/jdplus-toolkit-desktop-plugin/src/main/java/jdplus/toolkit/desktop/plugin/ui/properties/l2fprod/OutlierDescriptorsEditor.java
+++ b/jdplus-main-desktop/jdplus-toolkit-desktop-plugin/src/main/java/jdplus/toolkit/desktop/plugin/ui/properties/l2fprod/OutlierDescriptorsEditor.java
@@ -72,8 +72,9 @@ public class OutlierDescriptorsEditor extends AbstractPropertyEditor {
                             first = 1980;
                             last = Year.now(Clock.systemDefaultZone()).getValue();
                             frequency = UserInterfaceContext.INSTANCE.getAnnualFrequency();
-                            if (frequency == 0)
+                            if (frequency == 0) {
                                 frequency = 12;
+                            }
                         }
 
                         final JPanel pane = new JPanel(new BorderLayout());
@@ -129,15 +130,15 @@ public class OutlierDescriptorsEditor extends AbstractPropertyEditor {
 //                            final JComboBox comboFreq = new JComboBox(new Integer[]{1, 4, 12});
 //                            comboFreq.setSelectedItem(frequency);
 //                            topPane.add(comboFreq);
-                               final int AnnualFrequency=frequency;
+                            final int AnnualFrequency = frequency;
                             spinnerFirst.addChangeListener((ChangeEvent e1) -> {
                                 if ((Integer) spinnerFirst.getValue() > (Integer) spinnerLast.getValue()) {
                                     spinnerLast.setValue(spinnerFirst.getValue());
                                 } else {
                                     table.setModel(new OutliersModel((Integer) spinnerFirst.getValue(),
                                             (Integer) spinnerLast.getValue(),
-                                            AnnualFrequency, 
-//                                            (Integer) comboFreq.getSelectedItem(),
+                                            AnnualFrequency,
+                                            //                                            (Integer) comboFreq.getSelectedItem(),
                                             definitions_ != null ? definitions_ : new HashMap<>()));
                                 }
                             });
@@ -148,8 +149,8 @@ public class OutlierDescriptorsEditor extends AbstractPropertyEditor {
                                 } else {
                                     table.setModel(new OutliersModel((Integer) spinnerFirst.getValue(),
                                             (Integer) spinnerLast.getValue(),
-                                            AnnualFrequency, 
-//                                            (Integer) comboFreq.getSelectedItem(),
+                                            AnnualFrequency,
+                                            //                                            (Integer) comboFreq.getSelectedItem(),
                                             definitions_ != null ? definitions_ : new HashMap<>()));
                                 }
                             });
@@ -162,7 +163,6 @@ public class OutlierDescriptorsEditor extends AbstractPropertyEditor {
 //                                            definitions_ != null ? definitions_ : new HashMap<>()));
 //                                }
 //                            });
-
                             pane.add(topPane, BorderLayout.NORTH);
                         }
 
@@ -188,7 +188,7 @@ public class OutlierDescriptorsEditor extends AbstractPropertyEditor {
 
                     case LIST: {
                         final ArrayEditorDialog<OutlierDescriptor> arrayEditorDialog = new ArrayEditorDialog<>(ancestor,
-                                null != definitions_ ? getDescriptors() : new OutlierDescriptor[]{}, 
+                                null != definitions_ ? getDescriptors() : new OutlierDescriptor[]{},
                                 OutlierDescriptor::new, OutlierDescriptor::duplicate);
                         arrayEditorDialog.setTitle("Pre-specified outliers");
                         arrayEditorDialog.setLocationRelativeTo(ancestor);
@@ -238,7 +238,7 @@ public class OutlierDescriptorsEditor extends AbstractPropertyEditor {
                 .values()
                 .stream().flatMap(Collection::stream)
                 .map(OutlierDescriptor::new)
-                .sorted((o1, o2)->o1.getPosition().compareTo(o2.getPosition()))
+                .sorted((o1, o2) -> o1.getPosition().compareTo(o2.getPosition()))
                 .toArray(OutlierDescriptor[]::new);
     }
 
@@ -307,27 +307,19 @@ public class OutlierDescriptorsEditor extends AbstractPropertyEditor {
         @Override
         public String getColumnName(int column) {
             switch (freq_) {
-                case 12:
+                case 12 -> {
                     if (column > 0) {
                         return months[column - 1];
                     } else {
                         return "";
                     }
-                case 4:
-                    switch (column) {
-                        case 1:
-                            return "I";
-                        case 2:
-                            return "II";
-                        case 3:
-                            return "III";
-                        case 4:
-                            return "IV";
-                        default:
-                            return "";
-                    }
-                default:
-                    return "";
+                }
+                case 4 -> {
+                    return "Q" + column;
+                }
+                default -> {
+                    return Integer.toString(column);
+                }
             }
         }
 

--- a/jdplus-main-desktop/jdplus-toolkit-desktop-plugin/src/main/java/jdplus/toolkit/desktop/plugin/ui/properties/l2fprod/OutlierDescriptorsEditor.java
+++ b/jdplus-main-desktop/jdplus-toolkit-desktop-plugin/src/main/java/jdplus/toolkit/desktop/plugin/ui/properties/l2fprod/OutlierDescriptorsEditor.java
@@ -66,12 +66,14 @@ public class OutlierDescriptorsEditor extends AbstractPropertyEditor {
                                 frequency;
                         if (UserInterfaceContext.INSTANCE.getDomain() != null) {
                             first = UserInterfaceContext.INSTANCE.getDomain().getStartPeriod().year();
-                            last = UserInterfaceContext.INSTANCE.getDomain().getEndPeriod().year();
+                            last = UserInterfaceContext.INSTANCE.getDomain().getLastPeriod().year();
                             frequency = UserInterfaceContext.INSTANCE.getDomain().getAnnualFrequency();
                         } else {
                             first = 1980;
                             last = Year.now(Clock.systemDefaultZone()).getValue();
-                            frequency = 12;
+                            frequency = UserInterfaceContext.INSTANCE.getAnnualFrequency();
+                            if (frequency == 0)
+                                frequency = 12;
                         }
 
                         final JPanel pane = new JPanel(new BorderLayout());
@@ -121,20 +123,21 @@ public class OutlierDescriptorsEditor extends AbstractPropertyEditor {
                             final JSpinner spinnerLast = new JSpinner(new SpinnerNumberModel(last, 1950, last, 1));
                             spinnerLast.setEditor(new JSpinner.NumberEditor(spinnerLast, "#"));
                             topPane.add(spinnerLast);
-                            topPane.add(Box.createHorizontalStrut(20));
-                            topPane.add(new JLabel("Frequency:"));
-                            topPane.add(Box.createHorizontalStrut(10));
-                            final JComboBox comboFreq = new JComboBox(new Integer[]{1, 4, 12});
-                            comboFreq.setSelectedItem(frequency);
-                            topPane.add(comboFreq);
-
+//                            topPane.add(Box.createHorizontalStrut(20));
+//                            topPane.add(new JLabel("Frequency:"));
+//                            topPane.add(Box.createHorizontalStrut(10));
+//                            final JComboBox comboFreq = new JComboBox(new Integer[]{1, 4, 12});
+//                            comboFreq.setSelectedItem(frequency);
+//                            topPane.add(comboFreq);
+                               final int AnnualFrequency=frequency;
                             spinnerFirst.addChangeListener((ChangeEvent e1) -> {
                                 if ((Integer) spinnerFirst.getValue() > (Integer) spinnerLast.getValue()) {
                                     spinnerLast.setValue(spinnerFirst.getValue());
                                 } else {
                                     table.setModel(new OutliersModel((Integer) spinnerFirst.getValue(),
                                             (Integer) spinnerLast.getValue(),
-                                            (Integer) comboFreq.getSelectedItem(),
+                                            AnnualFrequency, 
+//                                            (Integer) comboFreq.getSelectedItem(),
                                             definitions_ != null ? definitions_ : new HashMap<>()));
                                 }
                             });
@@ -145,19 +148,20 @@ public class OutlierDescriptorsEditor extends AbstractPropertyEditor {
                                 } else {
                                     table.setModel(new OutliersModel((Integer) spinnerFirst.getValue(),
                                             (Integer) spinnerLast.getValue(),
-                                            (Integer) comboFreq.getSelectedItem(),
+                                            AnnualFrequency, 
+//                                            (Integer) comboFreq.getSelectedItem(),
                                             definitions_ != null ? definitions_ : new HashMap<>()));
                                 }
                             });
 
-                            comboFreq.addItemListener((ItemEvent e1) -> {
-                                if (e1.getStateChange() == ItemEvent.SELECTED) {
-                                    table.setModel(new OutliersModel((Integer) spinnerFirst.getValue(),
-                                            (Integer) spinnerLast.getValue(),
-                                            (Integer) comboFreq.getSelectedItem(),
-                                            definitions_ != null ? definitions_ : new HashMap<>()));
-                                }
-                            });
+//                            comboFreq.addItemListener((ItemEvent e1) -> {
+//                                if (e1.getStateChange() == ItemEvent.SELECTED) {
+//                                    table.setModel(new OutliersModel((Integer) spinnerFirst.getValue(),
+//                                            (Integer) spinnerLast.getValue(),
+//                                            (Integer) comboFreq.getSelectedItem(),
+//                                            definitions_ != null ? definitions_ : new HashMap<>()));
+//                                }
+//                            });
 
                             pane.add(topPane, BorderLayout.NORTH);
                         }

--- a/jdplus-main-desktop/jdplus-toolkit-desktop-plugin/src/main/java/jdplus/toolkit/desktop/plugin/ui/properties/l2fprod/UserInterfaceContext.java
+++ b/jdplus-main-desktop/jdplus-toolkit-desktop-plugin/src/main/java/jdplus/toolkit/desktop/plugin/ui/properties/l2fprod/UserInterfaceContext.java
@@ -2,21 +2,35 @@ package jdplus.toolkit.desktop.plugin.ui.properties.l2fprod;
 
 import jdplus.toolkit.base.api.timeseries.TsDomain;
 
-
 /**
  *
  * @author Demortier Jeremy
  */
 public enum UserInterfaceContext {
-  INSTANCE;
+    INSTANCE;
 
-  private TsDomain domain_;
+    private TsDomain domain_ = null;
+    private int annualFrequency_ = 0;
 
-  public TsDomain getDomain() {
-    return domain_;
-  }
+    public TsDomain getDomain() {
+        return domain_;
+    }
 
-  public void setDomain(TsDomain domain) {
-    this.domain_ = domain;
-  }
+    public int getAnnualFrequency() {
+        return domain_ == null ? annualFrequency_ : domain_.getAnnualFrequency();
+    }
+
+    public void setDomain(TsDomain domain) {
+        this.domain_ = domain;
+    }
+
+    public void setAnnualFrequency(int freq) {
+        annualFrequency_ = freq;
+    }
+
+    public void reset() {
+        this.domain_ = null;
+        this.annualFrequency_ = 0;
+    }
+
 }

--- a/jdplus-main-desktop/jdplus-toolkit-desktop-plugin/src/main/java/jdplus/toolkit/desktop/plugin/workspace/ui/WorkspaceTsTopComponent.java
+++ b/jdplus-main-desktop/jdplus-toolkit-desktop-plugin/src/main/java/jdplus/toolkit/desktop/plugin/workspace/ui/WorkspaceTsTopComponent.java
@@ -36,7 +36,7 @@ public abstract class WorkspaceTsTopComponent<T extends TsDocument<?, ?>> extend
 
     protected abstract TsProcessingViewer initViewer();
 
-    public void updateUserInterfaceContext() {
+    private void updateUserInterfaceContext() {
         if (getDocument() == null) {
             return;
         }
@@ -59,9 +59,9 @@ public abstract class WorkspaceTsTopComponent<T extends TsDocument<?, ?>> extend
         updateUserInterfaceContext();
     }
 
-     @Override
+    @Override
     public void componentDeactivated() {
-        super.componentActivated();
+        super.componentDeactivated();
         UserInterfaceContext.INSTANCE.setDomain(null);
     }
 
@@ -137,12 +137,28 @@ public abstract class WorkspaceTsTopComponent<T extends TsDocument<?, ?>> extend
         } else {
             cts = ts.load(TsInformationType.All, TsManager.get()).freeze();
         }
-        panel.getDocument().set(cts);
-        panel.updateButtons(null);
-        getDocument().setDirty();
         WorkspaceItem<T> d = getDocument();
-        WorkspaceFactory.Event ev = new WorkspaceFactory.Event(d.getOwner(), d.getId(), WorkspaceFactory.Event.ITEMCHANGED, this);
-        WorkspaceFactory.getInstance().notifyEvent(ev);
+        if (update(d.getElement(), cts)) {
+            d.setDirty();
+            WorkspaceFactory.Event ev = new WorkspaceFactory.Event(d.getOwner(), d.getId(), WorkspaceFactory.Event.ITEMCHANGED, this);
+            WorkspaceFactory.getInstance().notifyEvent(ev);
+            panel.updateButtons(null);
 
+        }
+
+//        panel.getDocument().set(cts);
+//        panel.updateButtons(null);
+//        getDocument().setDirty();
+//        WorkspaceItem<T> d = getDocument();
+//        WorkspaceFactory.Event ev = new WorkspaceFactory.Event(d.getOwner(), d.getId(), WorkspaceFactory.Event.ITEMCHANGED, this);
+//        WorkspaceFactory.getInstance().notifyEvent(ev);
+    }
+
+    public boolean update(T element, Ts s) {
+        if (s != null) {
+            UserInterfaceContext.INSTANCE.setDomain(s.getData().getDomain());
+        }
+        element.set(s);
+        return true;
     }
 }

--- a/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramo/descriptors/BaseTramoSpecUI.java
+++ b/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramo/descriptors/BaseTramoSpecUI.java
@@ -69,6 +69,10 @@ abstract class BaseTramoSpecUI implements IPropertyDescriptors{
         root.core = root.core.toBuilder().transform(spec).build();
     }
 
+    void update(int freq) {
+        root.core = root.core.setFrequency(freq);
+    }
+
     void update(CalendarSpec spec) {
         update(root.core.getRegression()
                 .toBuilder()

--- a/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramo/descriptors/BasicSpecUI.java
+++ b/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramo/descriptors/BasicSpecUI.java
@@ -14,6 +14,7 @@ import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.util.ArrayList;
 import java.util.List;
+import jdplus.toolkit.base.api.timeseries.calendars.RegularFrequency;
 
 /**
  *
@@ -25,11 +26,21 @@ public class BasicSpecUI extends BaseTramoSpecUI {
         super(root);
     }
 
-    public DateSelectorUI getSpan() {
-        return new DateSelectorUI(core().getTransform().getSpan(), UserInterfaceContext.INSTANCE.getDomain(), isRo(), selector->updateSpan(selector));
+    public RegularFrequency getFrequency() {
+        return RegularFrequency.parse(core().getFrequency());
     }
-    
-    public void updateSpan(TimeSelector span){
+
+    public void setFrequency(RegularFrequency freq) {
+        int ifreq = freq.toInt();
+        update(ifreq);
+        UserInterfaceContext.INSTANCE.setAnnualFrequency(ifreq);
+    }
+
+    public DateSelectorUI getSpan() {
+        return new DateSelectorUI(core().getTransform().getSpan(), UserInterfaceContext.INSTANCE.getDomain(), isRo(), selector -> updateSpan(selector));
+    }
+
+    public void updateSpan(TimeSelector span) {
         update(core().getTransform().toBuilder().span(span).build());
     }
 
@@ -46,7 +57,11 @@ public class BasicSpecUI extends BaseTramoSpecUI {
     @Override
     public List<EnhancedPropertyDescriptor> getProperties() {
         ArrayList<EnhancedPropertyDescriptor> descs = new ArrayList<>();
-        EnhancedPropertyDescriptor desc = spanDesc();
+        EnhancedPropertyDescriptor desc = freqDesc();
+        if (desc != null) {
+            descs.add(desc);
+        }
+        desc = spanDesc();
         if (desc != null) {
             descs.add(desc);
         }
@@ -67,7 +82,25 @@ public class BasicSpecUI extends BaseTramoSpecUI {
         return Bundle.basicSpecUI_getDislayName();
     }
     ///////////////////////////////////////////////////////////////////////////
-    private static final int SPAN_ID = 1, AUTOMDL_ID = 2, PRELIMINARYCHECK_ID = 3;
+    private static final int SPAN_ID = 1, AUTOMDL_ID = 2, PRELIMINARYCHECK_ID = 3, FREQ_ID = 0;
+
+    @Messages({
+        "basicSpecUI.freqDesc.name=Frequency",
+        "basicSpecUI.freqDesc.desc=Number of periods in one year"
+    })
+    private EnhancedPropertyDescriptor freqDesc() {
+        try {
+            PropertyDescriptor desc = new PropertyDescriptor("frequency", this.getClass());
+            EnhancedPropertyDescriptor edesc = new EnhancedPropertyDescriptor(desc, FREQ_ID);
+            edesc.setRefreshMode(EnhancedPropertyDescriptor.Refresh.All);
+            desc.setShortDescription(Bundle.basicSpecUI_freqDesc_desc());
+            desc.setDisplayName(Bundle.basicSpecUI_freqDesc_name());
+            edesc.setReadOnly(isRo() || UserInterfaceContext.INSTANCE.getDomain() != null);
+            return edesc;
+        } catch (IntrospectionException ex) {
+            return null;
+        }
+    }
 
     @Messages({
         "basicSpecUI.spanDesc.name=Series span",

--- a/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramo/descriptors/BasicSpecUI.java
+++ b/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramo/descriptors/BasicSpecUI.java
@@ -14,7 +14,7 @@ import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.util.ArrayList;
 import java.util.List;
-import jdplus.toolkit.base.api.timeseries.calendars.RegularFrequency;
+import jdplus.tramoseats.base.api.tramo.TramoFrequency;
 
 /**
  *
@@ -26,12 +26,14 @@ public class BasicSpecUI extends BaseTramoSpecUI {
         super(root);
     }
 
-    public RegularFrequency getFrequency() {
-        return RegularFrequency.parse(core().getFrequency());
+    public TramoFrequency getFrequency() {
+        return TramoFrequency.parse(core().getFrequency());
     }
 
-    public void setFrequency(RegularFrequency freq) {
+    public void setFrequency(TramoFrequency freq) {
         int ifreq = freq.toInt();
+        if (ifreq < 0)
+            throw new IllegalArgumentException("Can't be used. For legacy purposes only");
         update(ifreq);
         UserInterfaceContext.INSTANCE.setAnnualFrequency(ifreq);
     }
@@ -83,6 +85,7 @@ public class BasicSpecUI extends BaseTramoSpecUI {
     }
     ///////////////////////////////////////////////////////////////////////////
     private static final int SPAN_ID = 1, AUTOMDL_ID = 2, PRELIMINARYCHECK_ID = 3, FREQ_ID = 0;
+    
 
     @Messages({
         "basicSpecUI.freqDesc.name=Frequency",

--- a/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramo/descriptors/RegressionSpecUI.java
+++ b/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramo/descriptors/RegressionSpecUI.java
@@ -187,6 +187,10 @@ public class RegressionSpecUI extends BaseTramoSpecUI {
     public MeanSpecUI getMean() {
         return new MeanSpecUI(root);
     }
+    
+    public boolean isRegressionRo(){
+        return root.isRo() || root.getCore().getFrequency() == -1;
+    }
 
     private static final int MEAN_ID = 1, CALENDAR_ID = 2, PRESPEC_ID = 3, INTERV_ID = 4, RAMPS_ID = 5, USERDEF_ID = 6;
 
@@ -223,7 +227,7 @@ public class RegressionSpecUI extends BaseTramoSpecUI {
             edesc.setRefreshMode(EnhancedPropertyDescriptor.Refresh.All);
             desc.setDisplayName(Bundle.regressionSpecUI_prespecDesc_name());
             desc.setShortDescription(Bundle.regressionSpecUI_prespecDesc_desc());
-            edesc.setReadOnly(isRo());
+            edesc.setReadOnly(isRegressionRo());
             return edesc;
         } catch (IntrospectionException ex) {
             return null;
@@ -244,7 +248,7 @@ public class RegressionSpecUI extends BaseTramoSpecUI {
             edesc.setRefreshMode(EnhancedPropertyDescriptor.Refresh.All);
             desc.setDisplayName(Bundle.regressionSpecUI_interventionDesc_name());
             desc.setShortDescription(Bundle.regressionSpecUI_interventionDesc_desc());
-            edesc.setReadOnly(isRo());
+            edesc.setReadOnly(isRegressionRo());
             return edesc;
         } catch (IntrospectionException ex) {
             return null;
@@ -265,7 +269,7 @@ public class RegressionSpecUI extends BaseTramoSpecUI {
             edesc.setRefreshMode(EnhancedPropertyDescriptor.Refresh.All);
             desc.setDisplayName(Bundle.regressionSpecUI_rampsDesc_name());
             desc.setShortDescription(Bundle.regressionSpecUI_rampsDesc_desc());
-            edesc.setReadOnly(isRo());
+            edesc.setReadOnly(isRegressionRo());
             return edesc;
         } catch (IntrospectionException ex) {
             return null;
@@ -286,7 +290,7 @@ public class RegressionSpecUI extends BaseTramoSpecUI {
             edesc.setRefreshMode(EnhancedPropertyDescriptor.Refresh.All);
             desc.setDisplayName(Bundle.regressionSpecUI_userdefinedDesc_name());
             desc.setShortDescription(Bundle.regressionSpecUI_userdefinedDesc_desc());
-            edesc.setReadOnly(isRo());
+            edesc.setReadOnly(isRegressionRo());
             return edesc;
         } catch (IntrospectionException ex) {
             return null;

--- a/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramo/descriptors/RegressionSpecUI.java
+++ b/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramo/descriptors/RegressionSpecUI.java
@@ -214,6 +214,9 @@ public class RegressionSpecUI extends BaseTramoSpecUI {
         "regressionSpecUI.prespecDesc.desc=Pre-specified outliers"
     })
     private EnhancedPropertyDescriptor prespecDesc() {
+        if (core().getFrequency() == 0) {
+            return null;
+        }
         try {
             PropertyDescriptor desc = new PropertyDescriptor("PreSpecifiedOutliers", this.getClass());
             EnhancedPropertyDescriptor edesc = new EnhancedPropertyDescriptor(desc, PRESPEC_ID);
@@ -232,6 +235,9 @@ public class RegressionSpecUI extends BaseTramoSpecUI {
         "regressionSpecUI.interventionDesc.desc=Intervention variables"
     })
     private EnhancedPropertyDescriptor interventionDesc() {
+        if (core().getFrequency() == 0) {
+            return null;
+        }
         try {
             PropertyDescriptor desc = new PropertyDescriptor("InterventionVariables", this.getClass());
             EnhancedPropertyDescriptor edesc = new EnhancedPropertyDescriptor(desc, INTERV_ID);
@@ -250,6 +256,9 @@ public class RegressionSpecUI extends BaseTramoSpecUI {
         "regressionSpecUI.rampsDesc.desc=Ramps"
     })
     private EnhancedPropertyDescriptor rampsDesc() {
+        if (core().getFrequency() == 0) {
+            return null;
+        }
         try {
             PropertyDescriptor desc = new PropertyDescriptor("Ramps", this.getClass());
             EnhancedPropertyDescriptor edesc = new EnhancedPropertyDescriptor(desc, RAMPS_ID);
@@ -268,6 +277,9 @@ public class RegressionSpecUI extends BaseTramoSpecUI {
         "regressionSpecUI.userdefinedDesc.desc=User-defined variables"
     })
     private EnhancedPropertyDescriptor userdefinedDesc() {
+        if (core().getFrequency() == 0) {
+            return null;
+        }
         try {
             PropertyDescriptor desc = new PropertyDescriptor("UserDefinedVariables", this.getClass());
             EnhancedPropertyDescriptor edesc = new EnhancedPropertyDescriptor(desc, USERDEF_ID);

--- a/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramo/documents/TramoSpecManager.java
+++ b/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramo/documents/TramoSpecManager.java
@@ -32,6 +32,7 @@ import java.util.List;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.Icon;
+import jdplus.toolkit.desktop.plugin.ui.properties.l2fprod.UserInterfaceContext;
 import jdplus.tramoseats.base.workspace.TramoSeatsHandlers;
 
 import org.openide.util.ImageUtilities;
@@ -98,7 +99,7 @@ public class TramoSpecManager extends AbstractWorkspaceItemManager<TramoSpec> {
     @Override
     public Icon getManagerIcon() {
         return ImageUtilities.loadImageIcon("jdplus/tramoseats/desktop/plugin/tramoseats/api/blog_16x16.png", false);
-   }
+    }
 
     @Override
     public Icon getItemIcon(WorkspaceItem<TramoSpec> doc) {
@@ -124,6 +125,7 @@ public class TramoSpecManager extends AbstractWorkspaceItemManager<TramoSpec> {
 
         }
         final TramoSpecUI ui = new TramoSpecUI(xdoc.getElement(), xdoc.isReadOnly());
+        UserInterfaceContext.INSTANCE.setAnnualFrequency(xdoc.getElement().getFrequency());
         Frame owner = WindowManager.getDefault().getMainWindow();
         PropertiesDialog propDialog
                 = new PropertiesDialog(owner, true, ui,
@@ -131,6 +133,7 @@ public class TramoSpecManager extends AbstractWorkspaceItemManager<TramoSpec> {
                     @Override
                     public void actionPerformed(ActionEvent e) {
                         xdoc.setElement(ui.getCore());
+                        UserInterfaceContext.INSTANCE.setAnnualFrequency(0);
                     }
                 });
         propDialog.setTitle(xdoc.getDisplayName());

--- a/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramo/ui/TramoTopComponent.java
+++ b/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramo/ui/TramoTopComponent.java
@@ -4,13 +4,19 @@
  */
 package jdplus.tramoseats.desktop.plugin.tramo.ui;
 
+import jdplus.toolkit.base.api.timeseries.Ts;
+import jdplus.toolkit.base.api.timeseries.TsDomain;
 import jdplus.tramoseats.desktop.plugin.tramo.documents.TramoDocumentManager;
 import jdplus.tramoseats.base.core.tramo.TramoDocument;
 import jdplus.toolkit.desktop.plugin.ui.processing.TsProcessingViewer;
+import jdplus.toolkit.desktop.plugin.ui.properties.l2fprod.UserInterfaceContext;
 import jdplus.toolkit.desktop.plugin.workspace.DocumentUIServices;
 import jdplus.toolkit.desktop.plugin.workspace.WorkspaceFactory;
 import jdplus.toolkit.desktop.plugin.workspace.WorkspaceItem;
 import jdplus.toolkit.desktop.plugin.workspace.ui.WorkspaceTsTopComponent;
+import jdplus.tramoseats.base.api.tramo.TramoSpec;
+import jdplus.tramoseats.base.api.tramoseats.TramoSeatsSpec;
+import jdplus.tramoseats.base.core.tramoseats.TramoSeatsDocument;
 import nbbrd.design.ClassNameConstant;
 import org.openide.windows.TopComponent;
 import org.netbeans.api.settings.ConvertAsProperties;
@@ -59,6 +65,23 @@ public final class TramoTopComponent extends WorkspaceTsTopComponent<TramoDocume
         associateLookup(ExplorerUtils.createLookup(mgr, getActionMap()));
     }
 
+    private void updateUserInterfaceContext() {
+        if (getDocument() == null) {
+            return;
+        }
+        TramoDocument element = getElement();
+        if (element == null) {
+            UserInterfaceContext.INSTANCE.setDomain(null);
+        } else {
+            TramoSpec s = element.getSpecification();
+            if (s == null) {
+                UserInterfaceContext.INSTANCE.setAnnualFrequency(0);
+            } else {
+                UserInterfaceContext.INSTANCE.setAnnualFrequency(s.getFrequency());
+            }
+        }
+    }
+
     @Override
     public ExplorerManager getExplorerManager() {
         return mgr;
@@ -72,6 +95,18 @@ public final class TramoTopComponent extends WorkspaceTsTopComponent<TramoDocume
     @Override
     public WorkspaceItem<TramoDocument> newDocument() {
         return manager().create(WorkspaceFactory.getInstance().getActiveWorkspace());
+    }
+
+    @Override
+    public void componentActivated() {
+        super.componentActivated();
+        updateUserInterfaceContext();
+    }
+
+    @Override
+    public void componentDeactivated() {
+        super.componentDeactivated();
+        UserInterfaceContext.INSTANCE.setAnnualFrequency(0);
     }
 
     /**
@@ -101,4 +136,19 @@ public final class TramoTopComponent extends WorkspaceTsTopComponent<TramoDocume
     protected String getContextPath() {
         return TramoDocumentManager.CONTEXTPATH;
     }
+
+    @Override
+    public boolean update(TramoDocument element, Ts s) {
+        if (s != null) {
+            TsDomain domain = s.getData().getDomain();
+            UserInterfaceContext.INSTANCE.setDomain(domain);
+            TramoSpec nspec = element.getSpecification().setFrequency(domain.getAnnualFrequency());
+            element.set(nspec, s);
+        } else {
+            UserInterfaceContext.INSTANCE.setDomain(null);
+            element.set(s);
+        }
+        return true;
+    }
+
 }

--- a/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramoseats/documents/TramoSeatsSpecManager.java
+++ b/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramoseats/documents/TramoSeatsSpecManager.java
@@ -20,6 +20,7 @@ import java.util.List;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.Icon;
+import jdplus.toolkit.desktop.plugin.ui.properties.l2fprod.UserInterfaceContext;
 import jdplus.tramoseats.base.workspace.TramoSeatsHandlers;
 
 import org.openide.util.ImageUtilities;
@@ -111,12 +112,14 @@ public class TramoSeatsSpecManager extends AbstractWorkspaceItemManager<TramoSea
         }
         final TramoSeatsSpecUI ui = new TramoSeatsSpecUI(xdoc.getElement(), xdoc.isReadOnly());
         Frame owner = WindowManager.getDefault().getMainWindow();
+        UserInterfaceContext.INSTANCE.setAnnualFrequency(xdoc.getElement().getTramo().getFrequency());
         PropertiesDialog propDialog
                 = new PropertiesDialog(owner, true, ui,
                         new AbstractAction("OK") {
                     @Override
                     public void actionPerformed(ActionEvent e) {
                         xdoc.setElement(ui.getCore());
+                        UserInterfaceContext.INSTANCE.setAnnualFrequency(0);
                     }
                 });
         propDialog.setTitle(xdoc.getDisplayName());

--- a/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramoseats/ui/TramoSeatsTopComponent.java
+++ b/jdplus-main-desktop/jdplus-tramoseats-desktop-plugin/src/main/java/jdplus/tramoseats/desktop/plugin/tramoseats/ui/TramoSeatsTopComponent.java
@@ -4,12 +4,16 @@
  */
 package jdplus.tramoseats.desktop.plugin.tramoseats.ui;
 
+import jdplus.toolkit.base.api.timeseries.Ts;
+import jdplus.toolkit.base.api.timeseries.TsDomain;
 import jdplus.tramoseats.desktop.plugin.tramoseats.documents.TramoSeatsDocumentManager;
 import jdplus.toolkit.desktop.plugin.ui.processing.TsProcessingViewer;
+import jdplus.toolkit.desktop.plugin.ui.properties.l2fprod.UserInterfaceContext;
 import jdplus.toolkit.desktop.plugin.workspace.DocumentUIServices;
 import jdplus.toolkit.desktop.plugin.workspace.WorkspaceFactory;
 import jdplus.toolkit.desktop.plugin.workspace.WorkspaceItem;
 import jdplus.toolkit.desktop.plugin.workspace.ui.WorkspaceTsTopComponent;
+import jdplus.tramoseats.base.api.tramoseats.TramoSeatsSpec;
 import jdplus.tramoseats.base.core.tramoseats.TramoSeatsDocument;
 import nbbrd.design.ClassNameConstant;
 import org.openide.awt.ActionID;
@@ -72,13 +76,56 @@ public final class TramoSeatsTopComponent extends WorkspaceTsTopComponent<TramoS
         return TsProcessingViewer.create(getElement(), DocumentUIServices.forDocument(TramoSeatsDocument.class));
     }
 
+    @Override
+    public void componentActivated() {
+        super.componentActivated();
+        updateUserInterfaceContext();
+    }
+
+    @Override
+    public void componentDeactivated() {
+        super.componentDeactivated();
+        UserInterfaceContext.INSTANCE.setAnnualFrequency(0);
+    }
 
     private void initComponents() {
         setLayout(new java.awt.BorderLayout());
+    }
+
+    private void updateUserInterfaceContext() {
+        if (getDocument() == null) {
+            return;
+        }
+        TramoSeatsDocument element = getElement();
+        if (element == null) {
+            UserInterfaceContext.INSTANCE.setDomain(null);
+        } else {
+            TramoSeatsSpec s = element.getSpecification();
+            if (s == null) {
+                UserInterfaceContext.INSTANCE.setAnnualFrequency(0);
+            } else {
+                UserInterfaceContext.INSTANCE.setAnnualFrequency(s.getTramo().getFrequency());
+            }
+        }
     }
 
     @Override
     protected String getContextPath() {
         return TramoSeatsDocumentManager.CONTEXTPATH;
     }
+
+    @Override
+    public boolean update(TramoSeatsDocument element, Ts s) {
+        if (s != null) {
+            TsDomain domain = s.getData().getDomain();
+            UserInterfaceContext.INSTANCE.setDomain(domain);
+            TramoSeatsSpec nspec = element.getSpecification().setFrequency(domain.getAnnualFrequency());
+            element.set(nspec, s);
+        } else {
+            UserInterfaceContext.INSTANCE.setDomain(null);
+            element.set(s);
+        }
+        return true;
+    }
+
 }

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/regarima/descriptors/BaseRegArimaSpecUI.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/regarima/descriptors/BaseRegArimaSpecUI.java
@@ -38,10 +38,10 @@ abstract class BaseRegArimaSpecUI implements IPropertyDescriptors {
         return root.ro;
     }
 
-    boolean isTransformationDefined(){
+    boolean isTransformationDefined() {
         return root.getCore().getTransform().getFunction() != TransformationType.Auto;
     }
-    
+
     void update(BasicSpec spec) {
         root.core = root.core.toBuilder().basic(spec).build();
     }
@@ -90,4 +90,9 @@ abstract class BaseRegArimaSpecUI implements IPropertyDescriptors {
                 .tradingDays(spec)
                 .build());
     }
+
+    void update(int freq) {
+        root.core = root.core.setFrequency(freq);
+    }
+
 }

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/regarima/descriptors/BasicSpecUI.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/regarima/descriptors/BasicSpecUI.java
@@ -14,6 +14,7 @@ import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.util.ArrayList;
 import java.util.List;
+import jdplus.x13.base.api.regarima.X13Frequency;
 
 /**
  *
@@ -23,6 +24,16 @@ public class BasicSpecUI extends BaseRegArimaSpecUI {
 
     public BasicSpecUI(RegArimaSpecRoot root) {
         super(root);
+    }
+
+    public X13Frequency getFrequency() {
+        return X13Frequency.parse(core().getFrequency());
+    }
+
+    public void setFrequency(X13Frequency freq) {
+        int ifreq = freq.toInt();
+        update(ifreq);
+        UserInterfaceContext.INSTANCE.setAnnualFrequency(ifreq);
     }
 
     public DateSelectorUI getSpan() {
@@ -57,7 +68,11 @@ public class BasicSpecUI extends BaseRegArimaSpecUI {
     @Override
     public List<EnhancedPropertyDescriptor> getProperties() {
         ArrayList<EnhancedPropertyDescriptor> descs = new ArrayList<>();
-        EnhancedPropertyDescriptor desc = spanDesc();
+        EnhancedPropertyDescriptor desc = freqDesc();
+        if (desc != null) {
+            descs.add(desc);
+        }
+        desc = spanDesc();
         if (desc != null) {
             descs.add(desc);
         }
@@ -79,7 +94,25 @@ public class BasicSpecUI extends BaseRegArimaSpecUI {
         return Bundle.basicSpecUI_getDislayName();
     }
     ///////////////////////////////////////////////////////////////////////////
-    private static final int SPAN_ID = 1, AUTOMDL_ID = 2, PRELIMINARYCHECK_ID = 3;
+    private static final int SPAN_ID = 1, AUTOMDL_ID = 2, PRELIMINARYCHECK_ID = 3, FREQ_ID=0;
+
+   @Messages({
+        "basicSpecUI.freqDesc.name=Frequency",
+        "basicSpecUI.freqDesc.desc=Number of periods in one year"
+    })
+    private EnhancedPropertyDescriptor freqDesc() {
+        try {
+            PropertyDescriptor desc = new PropertyDescriptor("frequency", this.getClass());
+            EnhancedPropertyDescriptor edesc = new EnhancedPropertyDescriptor(desc, FREQ_ID);
+            edesc.setRefreshMode(EnhancedPropertyDescriptor.Refresh.All);
+            desc.setShortDescription(Bundle.basicSpecUI_freqDesc_desc());
+            desc.setDisplayName(Bundle.basicSpecUI_freqDesc_name());
+            edesc.setReadOnly(isRo() || UserInterfaceContext.INSTANCE.getDomain() != null);
+            return edesc;
+        } catch (IntrospectionException ex) {
+            return null;
+        }
+    }
 
     @Messages({
         "basicSpecUI.spanDesc.name=Series span",

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/regarima/descriptors/BasicSpecUI.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/regarima/descriptors/BasicSpecUI.java
@@ -32,6 +32,8 @@ public class BasicSpecUI extends BaseRegArimaSpecUI {
 
     public void setFrequency(X13Frequency freq) {
         int ifreq = freq.toInt();
+        if (ifreq < 0)
+            throw new IllegalArgumentException("Can't be used. For legacy purposes only");
         update(ifreq);
         UserInterfaceContext.INSTANCE.setAnnualFrequency(ifreq);
     }
@@ -107,7 +109,7 @@ public class BasicSpecUI extends BaseRegArimaSpecUI {
             edesc.setRefreshMode(EnhancedPropertyDescriptor.Refresh.All);
             desc.setShortDescription(Bundle.basicSpecUI_freqDesc_desc());
             desc.setDisplayName(Bundle.basicSpecUI_freqDesc_name());
-            edesc.setReadOnly(isRo() || UserInterfaceContext.INSTANCE.getDomain() != null);
+            edesc.setReadOnly(isRo() || (UserInterfaceContext.INSTANCE.getDomain() != null && core().getFrequency() == 0));
             return edesc;
         } catch (IntrospectionException ex) {
             return null;

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/regarima/descriptors/RegressionSpecUI.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/regarima/descriptors/RegressionSpecUI.java
@@ -213,6 +213,9 @@ public class RegressionSpecUI extends BaseRegArimaSpecUI {
         "regressionSpecUI.prespecDesc.desc=Pre-specified outliers"
     })
     private EnhancedPropertyDescriptor prespecDesc() {
+        if (core().getFrequency() == 0) {
+            return null;
+        }
         try {
             PropertyDescriptor desc = new PropertyDescriptor("PreSpecifiedOutliers", this.getClass());
             EnhancedPropertyDescriptor edesc = new EnhancedPropertyDescriptor(desc, PRESPEC_ID);
@@ -231,6 +234,9 @@ public class RegressionSpecUI extends BaseRegArimaSpecUI {
         "regressionSpecUI.interventionDesc.desc=Intervention variables"
     })
     private EnhancedPropertyDescriptor interventionDesc() {
+        if (core().getFrequency() == 0) {
+            return null;
+        }
         try {
             PropertyDescriptor desc = new PropertyDescriptor("InterventionVariables", this.getClass());
             EnhancedPropertyDescriptor edesc = new EnhancedPropertyDescriptor(desc, INTERV_ID);
@@ -249,6 +255,9 @@ public class RegressionSpecUI extends BaseRegArimaSpecUI {
         "regressionSpecUI.rampsDesc.desc=Ramps"
     })
     private EnhancedPropertyDescriptor rampsDesc() {
+        if (core().getFrequency() == 0) {
+            return null;
+        }
         try {
             PropertyDescriptor desc = new PropertyDescriptor("Ramps", this.getClass());
             EnhancedPropertyDescriptor edesc = new EnhancedPropertyDescriptor(desc, RAMPS_ID);
@@ -267,6 +276,9 @@ public class RegressionSpecUI extends BaseRegArimaSpecUI {
         "regressionSpecUI.userdefinedDesc.desc=User-defined variables"
     })
     private EnhancedPropertyDescriptor userdefinedDesc() {
+        if (core().getFrequency() == 0) {
+            return null;
+        }
         try {
             PropertyDescriptor desc = new PropertyDescriptor("UserDefinedVariables", this.getClass());
             EnhancedPropertyDescriptor edesc = new EnhancedPropertyDescriptor(desc, USERDEF_ID);

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/regarima/descriptors/RegressionSpecUI.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/regarima/descriptors/RegressionSpecUI.java
@@ -186,6 +186,11 @@ public class RegressionSpecUI extends BaseRegArimaSpecUI {
         return new MeanSpecUI(root);
     }
 
+    public boolean isRegressionRo(){
+        return root.isRo() || root.getCore().getFrequency() == -1;
+    }
+
+
     private static final int MEAN_ID = 0, CALENDAR_ID = 2, PRESPEC_ID = 3, INTERV_ID = 4, RAMPS_ID = 5, USERDEF_ID = 6, FCOEFF_ID = 7;
 
     @Messages({
@@ -222,7 +227,7 @@ public class RegressionSpecUI extends BaseRegArimaSpecUI {
             edesc.setRefreshMode(EnhancedPropertyDescriptor.Refresh.All);
             desc.setDisplayName(Bundle.regressionSpecUI_prespecDesc_name());
             desc.setShortDescription(Bundle.regressionSpecUI_prespecDesc_desc());
-            edesc.setReadOnly(isRo());
+            edesc.setReadOnly(isRegressionRo());
             return edesc;
         } catch (IntrospectionException ex) {
             return null;
@@ -243,7 +248,7 @@ public class RegressionSpecUI extends BaseRegArimaSpecUI {
             edesc.setRefreshMode(EnhancedPropertyDescriptor.Refresh.All);
             desc.setDisplayName(Bundle.regressionSpecUI_interventionDesc_name());
             desc.setShortDescription(Bundle.regressionSpecUI_interventionDesc_desc());
-            edesc.setReadOnly(isRo());
+            edesc.setReadOnly(isRegressionRo());
             return edesc;
         } catch (IntrospectionException ex) {
             return null;
@@ -264,7 +269,7 @@ public class RegressionSpecUI extends BaseRegArimaSpecUI {
             edesc.setRefreshMode(EnhancedPropertyDescriptor.Refresh.All);
             desc.setDisplayName(Bundle.regressionSpecUI_rampsDesc_name());
             desc.setShortDescription(Bundle.regressionSpecUI_rampsDesc_desc());
-            edesc.setReadOnly(isRo());
+            edesc.setReadOnly(isRegressionRo());
             return edesc;
         } catch (IntrospectionException ex) {
             return null;
@@ -285,7 +290,7 @@ public class RegressionSpecUI extends BaseRegArimaSpecUI {
             edesc.setRefreshMode(EnhancedPropertyDescriptor.Refresh.All);
             desc.setDisplayName(Bundle.regressionSpecUI_userdefinedDesc_name());
             desc.setShortDescription(Bundle.regressionSpecUI_userdefinedDesc_desc());
-            edesc.setReadOnly(isRo());
+            edesc.setReadOnly(isRegressionRo());
             return edesc;
         } catch (IntrospectionException ex) {
             return null;

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/regarima/documents/RegArimaSpecManager.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/regarima/documents/RegArimaSpecManager.java
@@ -32,6 +32,7 @@ import java.util.List;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.Icon;
+import jdplus.toolkit.desktop.plugin.ui.properties.l2fprod.UserInterfaceContext;
 import jdplus.x13.base.workspace.X13Handlers;
 
 import org.openide.util.ImageUtilities;
@@ -83,7 +84,7 @@ public class RegArimaSpecManager extends AbstractWorkspaceItemManager<RegArimaSp
 
     @Override
     public Action getPreferredItemAction(Id child) {
-         final WorkspaceItem<RegArimaSpec> xdoc = WorkspaceFactory.getInstance().getActiveWorkspace().searchDocument(child, RegArimaSpec.class);
+        final WorkspaceItem<RegArimaSpec> xdoc = WorkspaceFactory.getInstance().getActiveWorkspace().searchDocument(child, RegArimaSpec.class);
         if (xdoc == null || xdoc.getElement() == null) {
             return null;
         }
@@ -98,7 +99,7 @@ public class RegArimaSpecManager extends AbstractWorkspaceItemManager<RegArimaSp
     @Override
     public Icon getManagerIcon() {
         return ImageUtilities.loadImageIcon("jdplus/x13/desktop/plugin/x13/api/blog_16x16.png", false);
-   }
+    }
 
     @Override
     public Icon getItemIcon(WorkspaceItem<RegArimaSpec> doc) {
@@ -124,14 +125,16 @@ public class RegArimaSpecManager extends AbstractWorkspaceItemManager<RegArimaSp
         }
         final RegArimaSpecUI ui = new RegArimaSpecUI(xdoc.getElement(), xdoc.isReadOnly());
         Frame owner = WindowManager.getDefault().getMainWindow();
-        PropertiesDialog propDialog =
-                new PropertiesDialog(owner, true, ui,
-                new AbstractAction("OK") {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                xdoc.setElement(ui.getCore());
-            }
-        });
+        UserInterfaceContext.INSTANCE.setAnnualFrequency(xdoc.getElement().getFrequency());
+        PropertiesDialog propDialog
+                = new PropertiesDialog(owner, true, ui,
+                        new AbstractAction("OK") {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        xdoc.setElement(ui.getCore());
+                        UserInterfaceContext.INSTANCE.setAnnualFrequency(0);
+                    }
+                });
         propDialog.setTitle(xdoc.getDisplayName());
         propDialog.setLocationRelativeTo(owner);
         propDialog.setVisible(true);

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/regarima/ui/RegArimaTopComponent.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/regarima/ui/RegArimaTopComponent.java
@@ -4,12 +4,16 @@
  */
 package jdplus.x13.desktop.plugin.regarima.ui;
 
+import jdplus.toolkit.base.api.timeseries.Ts;
+import jdplus.toolkit.base.api.timeseries.TsDomain;
 import jdplus.x13.desktop.plugin.regarima.documents.RegArimaDocumentManager;
 import jdplus.toolkit.desktop.plugin.ui.processing.TsProcessingViewer;
+import jdplus.toolkit.desktop.plugin.ui.properties.l2fprod.UserInterfaceContext;
 import jdplus.toolkit.desktop.plugin.workspace.DocumentUIServices;
 import jdplus.toolkit.desktop.plugin.workspace.WorkspaceFactory;
 import jdplus.toolkit.desktop.plugin.workspace.WorkspaceItem;
 import jdplus.toolkit.desktop.plugin.workspace.ui.WorkspaceTsTopComponent;
+import jdplus.x13.base.api.regarima.RegArimaSpec;
 import jdplus.x13.base.core.x13.regarima.RegArimaDocument;
 import nbbrd.design.ClassNameConstant;
 import org.openide.windows.TopComponent;
@@ -101,4 +105,19 @@ public final class RegArimaTopComponent extends WorkspaceTsTopComponent<RegArima
     protected String getContextPath() {
         return RegArimaDocumentManager.CONTEXTPATH;
     }
+    
+        @Override
+    public boolean update(RegArimaDocument element, Ts s) {
+        if (s != null) {
+            TsDomain domain = s.getData().getDomain();
+            UserInterfaceContext.INSTANCE.setDomain(domain);
+            RegArimaSpec nspec = element.getSpecification().setFrequency(domain.getAnnualFrequency());
+            element.set(nspec, s);
+        } else {
+            UserInterfaceContext.INSTANCE.setDomain(null);
+            element.set(s);
+        }
+        return true;
+    }
+
 }

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/descriptors/BaseX13SpecUI.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/descriptors/BaseX13SpecUI.java
@@ -1,6 +1,17 @@
 /*
- * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
- * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.descriptors;
 

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/descriptors/X11SpecUI.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/descriptors/X11SpecUI.java
@@ -1,6 +1,17 @@
 /*
- * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
- * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.descriptors;
 
@@ -243,13 +254,21 @@ public class X11SpecUI extends BaseX13SpecUI {
     public SeasonalFilterOption[] getFullSeasonalMA() {
         SeasonalFilterOption[] filters = x11().getFilters();
         int len = period();
-        if (filters != null && filters.length == len) {
-            return filters;
+        boolean update = false;
+        if (filters != null) {
+            if (filters.length == len) {
+                return filters;
+            } else {
+                update = true;
+            }
         }
         SeasonalFilterOption option = filters == null ? SeasonalFilterOption.Msr : filters[0];
         filters = new SeasonalFilterOption[len];
         for (int i = 0; i < len; ++i) {
             filters[i] = option;
+        }
+        if (update) {
+            update(x11().toBuilder().filters(filters).build());
         }
         return filters;
 
@@ -302,17 +321,22 @@ public class X11SpecUI extends BaseX13SpecUI {
     public SigmaVecOption[] getSigmavec() {
         SigmaVecOption[] groups = x11().getSigmaVec();
         int len = period();
-        if (groups != null && groups.length == len) {
-            return groups;
+        boolean update = false;
+        if (groups != null) {
+            if (groups.length == len) {
+                return groups;
+            } else {
+                update = true;
+            }
         }
-        //Sigmavec option = groups == null ? Sigmavec.group1 : groups[0];
-        //   Sigmavec option = Sigmavec.group1;
         groups = new SigmaVecOption[len];
         for (int i = 0; i < len; ++i) {
             groups[i] = SigmaVecOption.Group1;
         }
+        if (update) {
+            update(x11().toBuilder().sigmaVec(groups).build());
+        }
         return groups;
-
     }
 
     public void setSigmavec(SigmaVecOption[] sigmavec) {

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/descriptors/X11SpecUI.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/descriptors/X11SpecUI.java
@@ -97,8 +97,7 @@ public class X11SpecUI extends BaseX13SpecUI {
     }
 
     int period() {
-        TsDomain domain = UserInterfaceContext.INSTANCE.getDomain();
-        return domain == null ? 12 : domain.getAnnualFrequency();
+        return UserInterfaceContext.INSTANCE.getAnnualFrequency();
     }
 
     boolean isPreprocessing() {
@@ -361,13 +360,17 @@ public class X11SpecUI extends BaseX13SpecUI {
 
     private static final int MODE_ID = 0, SEAS_ID = 1, FORECAST_ID = 2, BACKCAST_ID = 12, LSIGMA_ID = 3, USIGMA_ID = 4, AUTOTREND_ID = 5,
             TREND_ID = 6, SEASONMA_ID = 7, FULLSEASONMA_ID = 8, CALENDARSIGMA_ID = 9, SIGMAVEC_ID = 10, EXCLUDEFCST_ID = 11, BIAS_ID = 12;
+    
+    public boolean hasFrequency(){
+        return regarima().getBasic().getFrequency()>1;
+    }
 
     @Messages({
         "x11SpecUI.calendarsigmaDesc.name=Calendarsigma",
-        "x11SpecUI.calendarsigmaDesc.desc=[calendarsigma] Specifies if the standard errors used for extreme value detection and adjustment are computed separately for each calendar month (quarter), or separately for two complementary sets of calendar months (quarters)."
+        "x11SpecUI.calendarsigmaDesc.desc=[calendarsigma] Specifies if the standard errors used for extreme value detection and adjustment are computed separately for each calendar period, or separately for two complementary sets of calendar periods."
     })
     private EnhancedPropertyDescriptor calendarsigmaDesc() {
-        if (!x11().isSeasonal()) {
+        if (!x11().isSeasonal() || ! hasFrequency()) {
             return null;
         }
         try {
@@ -406,7 +409,7 @@ public class X11SpecUI extends BaseX13SpecUI {
         "x11SpecUI.sigmavecDesc.desc=[sigmavec] Specifies the two groups of periods (month or quarters) for whose irregulars a group standard error will be calculated under the calendarsigma=select option."
     })
     private EnhancedPropertyDescriptor sigmavecDesc() {
-        if (!x11().isSeasonal() || !x11().getCalendarSigma().equals(CalendarSigmaOption.Select)) {
+        if (!x11().isSeasonal() || !x11().getCalendarSigma().equals(CalendarSigmaOption.Select) || ! hasFrequency()) {
             return null;
         }
         try {
@@ -605,7 +608,7 @@ public class X11SpecUI extends BaseX13SpecUI {
         "x11SpecUI.fullseasonmaDesc.desc=[seasonalma] Details on specifc seasonalma for the different periods."
     })
     private EnhancedPropertyDescriptor fullseasonmaDesc() {
-        if (!x11().isSeasonal()) {
+        if (!x11().isSeasonal() || ! hasFrequency()) {
             return null;
         }
         try {

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/descriptors/X13SpecRoot.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/descriptors/X13SpecRoot.java
@@ -1,6 +1,17 @@
 /*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.descriptors;
 

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/descriptors/X13SpecUI.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/descriptors/X13SpecUI.java
@@ -1,6 +1,17 @@
 /*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.descriptors;
 

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/documents/X13DocFileRepository.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/documents/X13DocFileRepository.java
@@ -1,6 +1,17 @@
 /*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.documents;
 

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/documents/X13DocumentManager.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/documents/X13DocumentManager.java
@@ -1,6 +1,17 @@
 /*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.documents;
 

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/documents/X13SpecFileRepository.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/documents/X13SpecFileRepository.java
@@ -1,6 +1,17 @@
 /*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.documents;
 

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/documents/X13SpecManager.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/documents/X13SpecManager.java
@@ -1,6 +1,17 @@
 /*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.documents;
 
@@ -20,6 +31,7 @@ import java.util.List;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.Icon;
+import jdplus.toolkit.desktop.plugin.ui.properties.l2fprod.UserInterfaceContext;
 import jdplus.x13.base.workspace.X13Handlers;
 
 import org.openide.util.ImageUtilities;
@@ -69,7 +81,7 @@ public class X13SpecManager extends AbstractWorkspaceItemManager<X13Spec> {
 
     @Override
     public Action getPreferredItemAction(final Id child) {
-         final WorkspaceItem<X13Spec> xdoc = WorkspaceFactory.getInstance().getActiveWorkspace().searchDocument(child, X13Spec.class);
+        final WorkspaceItem<X13Spec> xdoc = WorkspaceFactory.getInstance().getActiveWorkspace().searchDocument(child, X13Spec.class);
         if (xdoc == null || xdoc.getElement() == null) {
             return null;
         }
@@ -84,7 +96,7 @@ public class X13SpecManager extends AbstractWorkspaceItemManager<X13Spec> {
     @Override
     public Icon getManagerIcon() {
         return ImageUtilities.loadImageIcon("jdplus/x13/desktop/plugin/x13/api/blog_16x16.png", false);
-   }
+    }
 
     @Override
     public Icon getItemIcon(WorkspaceItem<X13Spec> doc) {
@@ -111,19 +123,21 @@ public class X13SpecManager extends AbstractWorkspaceItemManager<X13Spec> {
         }
         final X13SpecUI ui = new X13SpecUI(xdoc.getElement(), xdoc.isReadOnly());
         Frame owner = WindowManager.getDefault().getMainWindow();
-        PropertiesDialog propDialog =
-                new PropertiesDialog(owner, true, ui,
-                new AbstractAction("OK") {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                xdoc.setElement(ui.getCore());
-            }
-        });
+        UserInterfaceContext.INSTANCE.setAnnualFrequency(xdoc.getElement().getFrequency());
+        PropertiesDialog propDialog
+                = new PropertiesDialog(owner, true, ui,
+                        new AbstractAction("OK") {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        xdoc.setElement(ui.getCore());
+                        UserInterfaceContext.INSTANCE.setAnnualFrequency(0);
+                    }
+                });
         propDialog.setTitle(xdoc.getDisplayName());
         propDialog.setLocationRelativeTo(owner);
         propDialog.setVisible(true);
     }
-    
+
     @Override
     public Class<X13Spec> getItemClass() {
         return X13Spec.class;

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/JX13Summary.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/JX13Summary.java
@@ -1,6 +1,17 @@
 /*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.ui;
 

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/X13OptionsPanelController.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/X13OptionsPanelController.java
@@ -1,6 +1,17 @@
 /*
- * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
- * Click nbfs://nbhost/SystemFileSystem/Templates/NetBeansModuleDevelopment-files/template_mypluginOptionsPanelController.java to edit this template
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.ui;
 

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/X13Panel.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/X13Panel.java
@@ -1,6 +1,17 @@
 /*
- * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
- * Click nbfs://nbhost/SystemFileSystem/Templates/NetBeansModuleDevelopment-files/template_mypluginPanel.java to edit this template
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.ui;
 

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/X13Summary.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/X13Summary.java
@@ -1,6 +1,17 @@
 /*
- * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
- * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.ui;
 

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/X13TopComponent.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/X13TopComponent.java
@@ -1,15 +1,30 @@
 /*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.ui;
 
+import jdplus.toolkit.base.api.timeseries.Ts;
+import jdplus.toolkit.base.api.timeseries.TsDomain;
 import jdplus.x13.desktop.plugin.x13.documents.X13DocumentManager;
 import jdplus.toolkit.desktop.plugin.ui.processing.TsProcessingViewer;
+import jdplus.toolkit.desktop.plugin.ui.properties.l2fprod.UserInterfaceContext;
 import jdplus.toolkit.desktop.plugin.workspace.DocumentUIServices;
 import jdplus.toolkit.desktop.plugin.workspace.WorkspaceFactory;
 import jdplus.toolkit.desktop.plugin.workspace.WorkspaceItem;
 import jdplus.toolkit.desktop.plugin.workspace.ui.WorkspaceTsTopComponent;
+import jdplus.x13.base.api.x13.X13Spec;
 import jdplus.x13.base.core.x13.X13Document;
 import nbbrd.design.ClassNameConstant;
 import org.netbeans.api.settings.ConvertAsProperties;
@@ -102,4 +117,19 @@ public final class X13TopComponent extends WorkspaceTsTopComponent<X13Document> 
     protected String getContextPath() {
         return X13DocumentManager.CONTEXTPATH;
     }
+    
+        @Override
+    public boolean update(X13Document element, Ts s) {
+        if (s != null) {
+            TsDomain domain = s.getData().getDomain();
+            UserInterfaceContext.INSTANCE.setDomain(domain);
+            X13Spec nspec = element.getSpecification().setFrequency(domain.getAnnualFrequency());
+            element.set(nspec, s);
+        } else {
+            UserInterfaceContext.INSTANCE.setDomain(null);
+            element.set(s);
+        }
+        return true;
+    }
+
 }

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/X13UI.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/X13UI.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
+ */
 package jdplus.x13.desktop.plugin.x13.ui;
 
 import jdplus.toolkit.desktop.plugin.Config;

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/X13UIFactory.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/X13UIFactory.java
@@ -1,6 +1,17 @@
 /*
- * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
- * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.ui;
 

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/X13ViewFactory.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/X13ViewFactory.java
@@ -1,6 +1,17 @@
 /*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.ui;
 

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/actions/CloneSpec.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/actions/CloneSpec.java
@@ -1,6 +1,17 @@
 /*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.ui.actions;
 

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/actions/EditX13Spec.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/actions/EditX13Spec.java
@@ -1,6 +1,17 @@
 /*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.ui.actions;
 

--- a/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/actions/OpenX13Doc.java
+++ b/jdplus-main-desktop/jdplus-x13-desktop-plugin/src/main/java/jdplus/x13/desktop/plugin/x13/ui/actions/OpenX13Doc.java
@@ -1,6 +1,17 @@
 /*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright 2026 JDemetra+.
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *      https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and
+ * limitations under the Licence.
  */
 package jdplus.x13.desktop.plugin.x13.ui.actions;
 


### PR DESCRIPTION
It will avoid incoherent specifications (for instance X11 filters not corresponding to the frequency of a series) and allow more tests.
Also, it will improve the GUI (for instance in the selection of pre-specified outliers).
The compatibility with existing workspaces is maintained.